### PR TITLE
Add pipeline smoke tests using github actions 

### DIFF
--- a/.github/workflows/github-actions-demo.yml
+++ b/.github/workflows/github-actions-demo.yml
@@ -1,0 +1,18 @@
+name: GitHub Actions Demo
+run-name: ${{ github.actor }} is testing out GitHub Actions 🚀
+on: [push]
+jobs:
+  Explore-GitHub-Actions:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "🎉 The job was automatically triggered by a ${{ github.event_name }} event."
+      - run: echo "🐧 This job is now running on a ${{ runner.os }} server hosted by GitHub!"
+      - run: echo "🔎 The name of your branch is ${{ github.ref }} and your repository is ${{ github.repository }}."
+      - name: Check out repository code
+        uses: actions/checkout@v3
+      - run: echo "💡 The ${{ github.repository }} repository has been cloned to the runner."
+      - run: echo "🖥️ The workflow is now ready to test your code on the runner."
+      - name: List files in the repository
+        run: |
+          ls ${{ github.workspace }}
+      - run: echo "🍏 This job's status is ${{ job.status }}."

--- a/.github/workflows/github-actions-demo.yml
+++ b/.github/workflows/github-actions-demo.yml
@@ -4,11 +4,13 @@ on: [ push ]
 jobs:
   Pipeline-Smoke-Tests:
     runs-on: ubuntu-latest
+
     steps:
       - name: Training Association Testing smoke tests
         uses: snakemake/snakemake-github-action@v1.24.0
         with:
-          directory: '.example'
-          snakefile: 'pipelines/training_association_testing.snakefile'
-          args: '-n'
+          directory: '${{ github.workspace }}/example'
+          snakefile: '${{ github.workspace }}/pipelines/training_association_testing.snakefile'
+          args: '-j 1 -n'
+          stagein: 'pip install -e ${{ github.workspace }}'
           task: 'run'

--- a/.github/workflows/github-actions-demo.yml
+++ b/.github/workflows/github-actions-demo.yml
@@ -1,18 +1,14 @@
-name: GitHub Actions Demo
-run-name: ${{ github.actor }} is testing out GitHub Actions 🚀
-on: [push]
+name: DeepRVAT
+run-name: DeepRVAT 🧬🧪💻🧑‍🔬
+on: [ push ]
 jobs:
-  Explore-GitHub-Actions:
+  Pipeline-Smoke-Tests:
     runs-on: ubuntu-latest
     steps:
-      - run: echo "🎉 The job was automatically triggered by a ${{ github.event_name }} event."
-      - run: echo "🐧 This job is now running on a ${{ runner.os }} server hosted by GitHub!"
-      - run: echo "🔎 The name of your branch is ${{ github.ref }} and your repository is ${{ github.repository }}."
-      - name: Check out repository code
-        uses: actions/checkout@v3
-      - run: echo "💡 The ${{ github.repository }} repository has been cloned to the runner."
-      - run: echo "🖥️ The workflow is now ready to test your code on the runner."
-      - name: List files in the repository
-        run: |
-          ls ${{ github.workspace }}
-      - run: echo "🍏 This job's status is ${{ job.status }}."
+      - name: Training Association Testing smoke tests
+        uses: snakemake/snakemake-github-action@v1.24.0
+        with:
+          directory: '.example'
+          snakefile: 'pipelines/training_association_testing.snakefile'
+          args: '-n'
+          task: 'run'

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -25,7 +25,6 @@ jobs:
       - name: Association Testing Pretrained Smoke Test
         uses: snakemake/snakemake-github-action@v1.24.0
         with:
-          stagein: 'ln -s ${{ github.workspace }}/pretrained_models ${{ github.workspace }}/example'
           directory: 'example'
           snakefile: 'pipelines/association_testing_pretrained.snakefile'
           args: '-j 1 -n'

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -2,9 +2,8 @@ name: DeepRVAT
 run-name: DeepRVAT 🧬🧪💻🧑‍🔬
 on: [ push ]
 jobs:
-  Pipeline-Smoke-Tests:
+  DeepRVAT-Pipeline-Smoke-Tests:
     runs-on: ubuntu-latest
-
     steps:
       - name: Check out repository code
         uses: actions/checkout@v3
@@ -27,6 +26,26 @@ jobs:
           directory: 'example'
           snakefile: 'pipelines/seed_gene_discovery.snakefile'
           args: '-j 1 -n'
+      - name: Association Testing Pretrained Smoke Test
+        uses: snakemake/snakemake-github-action@v1.24.0
+        with:
+          directory: 'example'
+          snakefile: 'pipelines/association_testing_pretrained.snakefile'
+          args: '-j 1 -n'
+      - name: Preprocess Smoke Test
+        uses: snakemake/snakemake-github-action@v1.24.0
+        with:
+          directory: 'example'
+          snakefile: 'pipelines/preprocess.snakefile'
+          args: '-j 1 -n --configfile pipelines/config/deeprvat_preprocess_config.yaml'
+  Pre-DeepRVAT-Pipeline-Smoke-Tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v3
+      - name: Training Association Testing smoke test
+        uses: snakemake/snakemake-github-action@v1.24.0
+        with:
       - name: Association Testing Pretrained Smoke Test
         uses: snakemake/snakemake-github-action@v1.24.0
         with:

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -20,10 +20,8 @@ jobs:
           directory: 'example'
           snakefile: 'pipelines/seed_gene_discovery.snakefile'
           args: '-j 1 -n'
-      - name: Copy pretrained models
+      - name: Link pretrained models
         run: cd ${{ github.workspace }}/example && ln -s ../pretrained_models
-      - name: List examples dir
-        run: ls -lah ${{ github.workspace }}/example
       - name: Association Testing Pretrained Smoke Test
         uses: snakemake/snakemake-github-action@v1.24.0
         with:

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           directory: 'example'
           snakefile: 'pipelines/annotations.snakefile'
-          args: '-j 1 -n --configfile ../pipelines/config/deeprvat_annotation_config.yaml'
+          args: '-j 1 -n --configfile pipelines/config/deeprvat_annotation_config.yaml'
       - name: Seed Gene Discovery Smoke Test
         uses: snakemake/snakemake-github-action@v1.24.0
         with:
@@ -38,4 +38,4 @@ jobs:
         with:
           directory: 'example'
           snakefile: 'pipelines/preprocess.snakefile'
-          args: '-j 1 -n --configfile ../pipelines/config/deeprvat_preprocess_config.yaml'
+          args: '-j 1 -n --configfile pipelines/config/deeprvat_preprocess_config.yaml'

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -2,7 +2,7 @@ name: DeepRVAT
 run-name: DeepRVAT 🧬🧪💻🧑‍🔬
 on: [ push ]
 jobs:
-  DeepRVAT-Pipeline-Smoke-Tests:
+  Main-DeepRVAT-Pipeline-Smoke-Tests:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository code
@@ -23,6 +23,7 @@ jobs:
       - name: Association Testing Pretrained Smoke Test
         uses: snakemake/snakemake-github-action@v1.24.0
         with:
+          stagein: 'ln -s pretrained_models example/pretrained_models'
           directory: 'example'
           snakefile: 'pipelines/association_testing_pretrained.snakefile'
           args: '-j 1 -n'

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -20,10 +20,12 @@ jobs:
           directory: 'example'
           snakefile: 'pipelines/seed_gene_discovery.snakefile'
           args: '-j 1 -n'
+      - name: Copy pretraines models
+        run: ln -s pretrained_models example/pretrained_models
       - name: Association Testing Pretrained Smoke Test
         uses: snakemake/snakemake-github-action@v1.24.0
         with:
-          stagein: 'ln -s pretrained_models example/pretrained_models'
+          stagein: 'ln -s ${{ github.workspace }}/pretrained_models ${{ github.workspace }}/example'
           directory: 'example'
           snakefile: 'pipelines/association_testing_pretrained.snakefile'
           args: '-j 1 -n'

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -33,6 +33,8 @@ jobs:
     steps:
       - name: Check out repository code
         uses: actions/checkout@v3
+      - name: Copy pretraines models
+        run: mkdir -pv vcf/metadata && touh vcf/metadata/pvcf_blocks.txt
       - name: Annotations Smoke Test
         uses: snakemake/snakemake-github-action@v1.24.0
         with:

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -9,8 +9,8 @@ jobs:
       - name: Training Association Testing smoke tests
         uses: snakemake/snakemake-github-action@v1.24.0
         with:
-          directory: '${{ github.workspace }}/example'
-          snakefile: '${{ github.workspace }}/pipelines/training_association_testing.snakefile'
+          directory: 'example'
+          snakefile: 'pipelines/training_association_testing.snakefile'
           args: '-j 1 -n'
           stagein: 'pip install -e ${{ github.workspace }}'
           task: 'run'

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -21,7 +21,7 @@ jobs:
           snakefile: 'pipelines/seed_gene_discovery.snakefile'
           args: '-j 1 -n'
       - name: Copy pretraines models
-        run: ln -s pretrained_models example/pretrained_models
+        run: ln -vs ${{ github.workspace }}/pretrained_models ${{ github.workspace }}/example
       - name: Association Testing Pretrained Smoke Test
         uses: snakemake/snakemake-github-action@v1.24.0
         with:

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -33,8 +33,8 @@ jobs:
     steps:
       - name: Check out repository code
         uses: actions/checkout@v3
-      - name: Copy pretraines models
-        run: mkdir -pv vcf/metadata && touch vcf/metadata/pvcf_blocks.txt
+      - name: Create pvcf_blocks.txt
+        run: mkdir -pv example/vcf/metadata && touch example/vcf/metadata/pvcf_blocks.txt
       - name: Annotations Smoke Test
         uses: snakemake/snakemake-github-action@v1.24.0
         with:

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Check out repository code
         uses: actions/checkout@v3
       - name: Copy pretraines models
-        run: mkdir -pv vcf/metadata && touh vcf/metadata/pvcf_blocks.txt
+        run: mkdir -pv vcf/metadata && touch vcf/metadata/pvcf_blocks.txt
       - name: Annotations Smoke Test
         uses: snakemake/snakemake-github-action@v1.24.0
         with:

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -6,6 +6,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Check out repository code
+        uses: actions/checkout@v3
       - name: Training Association Testing smoke tests
         uses: snakemake/snakemake-github-action@v1.24.0
         with:

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -15,12 +15,12 @@ jobs:
           snakefile: 'pipelines/training_association_testing.snakefile'
           args: '-j 1 -n'
           stagein: 'pip install -e ${{ github.workspace }}'
-      - name: annotations Smoke Test
+      - name: Annotations Smoke Test
         uses: snakemake/snakemake-github-action@v1.24.0
         with:
           directory: 'example'
           snakefile: 'pipelines/annotations.snakefile'
-          args: '-j 1 -n'
+          args: '-j 1 -n --configfile ../pipelines/config/deeprvat_annotation_config.yaml'
       - name: Seed Gene Discovery Smoke Test
         uses: snakemake/snakemake-github-action@v1.24.0
         with:
@@ -38,4 +38,4 @@ jobs:
         with:
           directory: 'example'
           snakefile: 'pipelines/preprocess.snakefile'
-          args: '-j 1 -n'
+          args: '-j 1 -n --configfile ../pipelines/config/deeprvat_preprocess_config.yaml'

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -20,8 +20,8 @@ jobs:
           directory: 'example'
           snakefile: 'pipelines/seed_gene_discovery.snakefile'
           args: '-j 1 -n'
-      - name: Copy pretraines models
-        run: ln -vs ${{ github.workspace }}/pretrained_models ${{ github.workspace }}/example
+      - name: Copy pretrained models
+        run: cd ${{ github.workspace }}/example && ln -s ../pretrained_models
       - name: List examples dir
         run: ls -lah ${{ github.workspace }}/example
       - name: Association Testing Pretrained Smoke Test

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -14,12 +14,6 @@ jobs:
           snakefile: 'pipelines/training_association_testing.snakefile'
           args: '-j 1 -n'
           stagein: 'pip install -e ${{ github.workspace }}'
-      - name: Annotations Smoke Test
-        uses: snakemake/snakemake-github-action@v1.24.0
-        with:
-          directory: 'example'
-          snakefile: 'pipelines/annotations.snakefile'
-          args: '-j 1 -n --configfile pipelines/config/deeprvat_annotation_config.yaml'
       - name: Seed Gene Discovery Smoke Test
         uses: snakemake/snakemake-github-action@v1.24.0
         with:
@@ -32,26 +26,17 @@ jobs:
           directory: 'example'
           snakefile: 'pipelines/association_testing_pretrained.snakefile'
           args: '-j 1 -n'
-      - name: Preprocess Smoke Test
-        uses: snakemake/snakemake-github-action@v1.24.0
-        with:
-          directory: 'example'
-          snakefile: 'pipelines/preprocess.snakefile'
-          args: '-j 1 -n --configfile pipelines/config/deeprvat_preprocess_config.yaml'
   Pre-DeepRVAT-Pipeline-Smoke-Tests:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository code
         uses: actions/checkout@v3
-      - name: Training Association Testing smoke test
-        uses: snakemake/snakemake-github-action@v1.24.0
-        with:
-      - name: Association Testing Pretrained Smoke Test
+      - name: Annotations Smoke Test
         uses: snakemake/snakemake-github-action@v1.24.0
         with:
           directory: 'example'
-          snakefile: 'pipelines/association_testing_pretrained.snakefile'
-          args: '-j 1 -n'
+          snakefile: 'pipelines/annotations.snakefile'
+          args: '-j 1 -n --configfile pipelines/config/deeprvat_annotation_config.yaml'
       - name: Preprocess Smoke Test
         uses: snakemake/snakemake-github-action@v1.24.0
         with:

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -22,6 +22,8 @@ jobs:
           args: '-j 1 -n'
       - name: Copy pretraines models
         run: ln -vs ${{ github.workspace }}/pretrained_models ${{ github.workspace }}/example
+      - name: List examples dir
+        run: ls -lah ${{ github.workspace }}/example
       - name: Association Testing Pretrained Smoke Test
         uses: snakemake/snakemake-github-action@v1.24.0
         with:

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -41,6 +41,8 @@ jobs:
           directory: 'example'
           snakefile: 'pipelines/annotations.snakefile'
           args: '-j 1 -n --configfile pipelines/config/deeprvat_annotation_config.yaml'
+      - name: Create pvcf_blocks.txt
+        run: mkdir -pv /data/metadata && touch /data/metadata/pvcf_blocks.txt
       - name: Preprocess Smoke Test
         uses: snakemake/snakemake-github-action@v1.24.0
         with:

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -8,11 +8,34 @@ jobs:
     steps:
       - name: Check out repository code
         uses: actions/checkout@v3
-      - name: Training Association Testing smoke tests
+      - name: Training Association Testing smoke test
         uses: snakemake/snakemake-github-action@v1.24.0
         with:
           directory: 'example'
           snakefile: 'pipelines/training_association_testing.snakefile'
           args: '-j 1 -n'
           stagein: 'pip install -e ${{ github.workspace }}'
-          task: 'run'
+      - name: annotations Smoke Test
+        uses: snakemake/snakemake-github-action@v1.24.0
+        with:
+          directory: 'example'
+          snakefile: 'pipelines/annotations.snakefile'
+          args: '-j 1 -n'
+      - name: Seed Gene Discovery Smoke Test
+        uses: snakemake/snakemake-github-action@v1.24.0
+        with:
+          directory: 'example'
+          snakefile: 'pipelines/seed_gene_discovery.snakefile'
+          args: '-j 1 -n'
+      - name: Association Testing Pretrained Smoke Test
+        uses: snakemake/snakemake-github-action@v1.24.0
+        with:
+          directory: 'example'
+          snakefile: 'pipelines/association_testing_pretrained.snakefile'
+          args: '-j 1 -n'
+      - name: Preprocess Smoke Test
+        uses: snakemake/snakemake-github-action@v1.24.0
+        with:
+          directory: 'example'
+          snakefile: 'pipelines/preprocess.snakefile'
+          args: '-j 1 -n'

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -2,7 +2,7 @@ name: DeepRVAT
 run-name: DeepRVAT 🧬🧪💻🧑‍🔬
 on: [ push ]
 jobs:
-  Main-DeepRVAT-Pipeline-Smoke-Tests:
+  DeepRVAT-Pipeline-Smoke-Tests:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository code
@@ -28,24 +28,3 @@ jobs:
           directory: 'example'
           snakefile: 'pipelines/association_testing_pretrained.snakefile'
           args: '-j 1 -n'
-  Pre-DeepRVAT-Pipeline-Smoke-Tests:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out repository code
-        uses: actions/checkout@v3
-      - name: Create pvcf_blocks.txt
-        run: mkdir -pv example/vcf/metadata && touch example/vcf/metadata/pvcf_blocks.txt
-      - name: Annotations Smoke Test
-        uses: snakemake/snakemake-github-action@v1.24.0
-        with:
-          directory: 'example'
-          snakefile: 'pipelines/annotations.snakefile'
-          args: '-j 1 -n --configfile pipelines/config/deeprvat_annotation_config.yaml'
-      - name: Create pvcf_blocks.txt
-        run: mkdir -pv /data/metadata && touch /data/metadata/pvcf_blocks.txt
-      - name: Preprocess Smoke Test
-        uses: snakemake/snakemake-github-action@v1.24.0
-        with:
-          directory: 'example'
-          snakefile: 'pipelines/preprocess.snakefile'
-          args: '-j 1 -n --configfile pipelines/config/deeprvat_preprocess_config.yaml'


### PR DESCRIPTION
This PR adds smoke tests for the main pipelines using github actions. It only runs the pipelines in "`dry-run`" mode but this should catch problems where the pipelines are not configured correctly. 

These are the snakemake files tested right now
```
         pipelines/training_association_testing.snakefile
         pipelines/seed_gene_discovery.snakefile
         pipelines/association_testing_pretrained.snakefile
```