### PR TITLE
Fix seed gene discovery pipeline with example data

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -62,3 +62,11 @@ jobs:
           python -m snakemake -j 2 --directory ${{ github.workspace }}/example \
           --snakefile ${{ github.workspace }}/pipelines/association_testing_pretrained.snakefile --show-failed-logs
         shell: micromamba-shell {0}
+      - name: Copy seed gene discovery snakemake config
+        run: cd ${{ github.workspace }}/example && cp ../deeprvat/seed_gene_discovery/config.yaml .
+        shell: bash -el {0}
+      - name: Run seed_gene_discovery pipeline
+        run: |
+          python -m snakemake -j 2 --directory ${{ github.workspace }}/example \
+          --snakefile ${{ github.workspace }}/pipelines/seed_gene_discovery.snakefile --show-failed-logs
+        shell: micromamba-shell {0}

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -15,12 +15,6 @@ jobs:
           snakefile: 'pipelines/training_association_testing.snakefile'
           args: '-j 2 -n'
           stagein: 'pip install -e ${{ github.workspace }}'
-      - name: Seed Gene Discovery Smoke Test
-        uses: snakemake/snakemake-github-action@v1.24.0
-        with:
-          directory: 'example'
-          snakefile: 'pipelines/seed_gene_discovery.snakefile'
-          args: '-j 2 -n'
       - name: Link pretrained models
         run: cd ${{ github.workspace }}/example && ln -s ../pretrained_models
       - name: Association Testing Pretrained Smoke Test
@@ -28,6 +22,12 @@ jobs:
         with:
           directory: 'example'
           snakefile: 'pipelines/association_testing_pretrained.snakefile'
+          args: '-j 2 -n'
+      - name: Seed Gene Discovery Smoke Test
+        uses: snakemake/snakemake-github-action@v1.24.0
+        with:
+          directory: 'example'
+          snakefile: 'pipelines/seed_gene_discovery.snakefile'
           args: '-j 2 -n'
 
   DeepRVAT-Pipeline-Tests:

--- a/TODOS.md
+++ b/TODOS.md
@@ -94,7 +94,7 @@ For each file:
 * [x] Create a minimal conda env with all required packages
 * [x] Create example files showing the input data format - **Brian**
   * `annotations.parquet`
-  * `genes.parquet`
+  * `protein_coding_genes.parquet`
   * `genotypes.h5`
   * `variants.parquet`
   * `config.yaml`

--- a/deeprvat/seed_gene_discovery/README.md
+++ b/deeprvat/seed_gene_discovery/README.md
@@ -20,3 +20,19 @@ The `annotations.parquet` data frame should have the following columns:
 - is_plof (binary, indicating if the variant is loss of function)
 - Consequence_missense_variant: 
 - MAF:  Maximum of the MAF in the UK Biobank cohort and in gnomAD release 3.0 (non-Finnish European population) can also be changed by using the --maf-column {maf_col_name} flag for the rule config and replacing MAF in the config.yaml with the {maf_col_name} but it must contain the string '_AF', '_MAF' OR '^MAF'
+
+### Run the seed gene discovery pipeline with example data  
+
+Create the conda environment and activate it, (instructions can be found in the [DeepRVAT README](https://github.com/PMBio/deeprvat/tree/main/README.md) )
+
+
+```
+mkdir example
+cd example
+ln -s [path_to_deeprvat]/example/* .
+cp [path_to_deeprvat]/deeprvat/seed_gene_discovery/config.yaml  .
+snakemake -j 1 --snakefile [path_to_deeprvat]/pipelines/seed_gene_discovery.snakefile
+```
+
+Replace `[path_to_deeprvat]` with the path to your clone of the repository.
+

--- a/deeprvat/seed_gene_discovery/README.md
+++ b/deeprvat/seed_gene_discovery/README.md
@@ -19,4 +19,4 @@ The `annotations.parquet` data frame should have the following columns:
 - gene_ids (list) gene(s) the variant is assigned to
 - is_plof (binary, indicating if the variant is loss of function)
 - Consequence_missense_variant: 
-- combined_UKB_NFE_AF:  Maximum of the MAF in the UK Biobank cohort and in gnomAD release 3.0 (non-Finnish European population) can also be changed by using the --maf-column {maf_col_name} flag for the rule config and replacing combined_UKB_NFE_AF in the config.yaml with the {maf_col_name} but it must contain the string '_AF' or '_MAF'
+- MAF:  Maximum of the MAF in the UK Biobank cohort and in gnomAD release 3.0 (non-Finnish European population) can also be changed by using the --maf-column {maf_col_name} flag for the rule config and replacing MAF in the config.yaml with the {maf_col_name} but it must contain the string '_AF', '_MAF' OR '^MAF'

--- a/deeprvat/seed_gene_discovery/README.md
+++ b/deeprvat/seed_gene_discovery/README.md
@@ -8,7 +8,7 @@ To run the pipeline, an experiment directory with the `config.yaml` has to be cr
 
 The experiment directory in addition requires to have the same input data as specified for [DeepRVAT](https://github.com/PMBio/deeprvat/tree/main/README.md), including
 - `annotations.parquet`
-- `genes.parquet`
+- `protein_coding_genes.parquet`
 - `genotypes.h5`
 - `variants.parquet`
 - `phenotypes.parquet`

--- a/deeprvat/seed_gene_discovery/config.yaml
+++ b/deeprvat/seed_gene_discovery/config.yaml
@@ -82,7 +82,7 @@ data:
             - MAF
             - is_plof
             - Consequence_missense_variant
-        gene_file: genes.parquet
+        gene_file: protein_coding_genes.parquet
         use_common_variants: False
         use_rare_variants: True
         rare_embedding:
@@ -92,7 +92,7 @@ data:
                     - MAF
                     - is_plof
                     - Consequence_missense_variant
-                gene_file: genes.parquet
+                gene_file: protein_coding_genes.parquet
                 verbose: True
         verbose: True
     dataloader_config:

--- a/deeprvat/seed_gene_discovery/config.yaml
+++ b/deeprvat/seed_gene_discovery/config.yaml
@@ -53,7 +53,7 @@ data:
         standardize_xpheno: False
         y_transformation: quantile_transform
         min_common_af:
-            combined_UKB_NFE_AF: 0.001 #is updated automatically when updating the config with update_config
+            MAF: 0.001 #is updated automatically when updating the config with update_config
         x_phenotypes:
             - age
             - genetic_sex
@@ -79,7 +79,7 @@ data:
             - genetic_PC_20
         annotation_file: annotations.parquet
         annotations:
-            - combined_UKB_NFE_AF
+            - MAF
             - is_plof
             - Consequence_missense_variant
         gene_file: genes.parquet
@@ -89,7 +89,7 @@ data:
             type: SparseGenotype 
             config:
                 annotations:
-                    - combined_UKB_NFE_AF
+                    - MAF
                     - is_plof
                     - Consequence_missense_variant
                 gene_file: genes.parquet

--- a/deeprvat/seed_gene_discovery/evaluate.py
+++ b/deeprvat/seed_gene_discovery/evaluate.py
@@ -3,7 +3,7 @@ import pickle
 import sys
 import os
 from pathlib import Path
-from typing import Dict
+from typing import Dict, Optional
 
 import click
 import pandas as pd
@@ -11,6 +11,7 @@ import plotnine as p9
 import numpy as np
 import scipy
 import yaml
+from statsmodels.stats.multitest import fdrcorrection
 from deeprvat.utils import pval_correction
 
 logging.basicConfig(

--- a/deeprvat/seed_gene_discovery/evaluate.py
+++ b/deeprvat/seed_gene_discovery/evaluate.py
@@ -3,7 +3,7 @@ import pickle
 import sys
 import os
 from pathlib import Path
-from typing import Dict, Optional
+from typing import Dict
 
 import click
 import pandas as pd
@@ -11,7 +11,6 @@ import plotnine as p9
 import numpy as np
 import scipy
 import yaml
-from statsmodels.stats.multitest import fdrcorrection
 from deeprvat.utils import pval_correction
 
 logging.basicConfig(

--- a/deeprvat/seed_gene_discovery/seed_gene_discovery.py
+++ b/deeprvat/seed_gene_discovery/seed_gene_discovery.py
@@ -9,15 +9,11 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
 import click
-import dask.dataframe as dd
 import numpy as np
 import pandas as pd
 import yaml
-import random
 from scipy.stats import beta
-from scipy.stats import norm
 from scipy.sparse import coo_matrix, spmatrix
-from statsmodels.stats.multitest import fdrcorrection
 from torch.utils.data import DataLoader, Dataset
 from tqdm import tqdm
 

--- a/deeprvat/seed_gene_discovery/seed_gene_discovery.py
+++ b/deeprvat/seed_gene_discovery/seed_gene_discovery.py
@@ -349,7 +349,7 @@ def run_association_(
     # Get column with minor allele frequency
     annotations = config["data"]["dataset_config"]["annotations"]
     maf_col = [
-        annotation for annotation in annotations if re.search(r"_AF|_MAF", annotation)
+        annotation for annotation in annotations if re.search(r"_AF|_MAF|^MAF", annotation)
     ]
     assert len(maf_col) == 1
     maf_col = maf_col[0]
@@ -412,7 +412,7 @@ def _add_annotation_cols(annotations, config):
 @click.option("--phenotype", type=str)
 @click.option("--variant-type", type=str)
 @click.option("--rare-maf", type=float)
-@click.option("--maf-column", type=str, default="combined_UKB_NFE_AF")
+@click.option("--maf-column", type=str, default="MAF")
 @click.option("--simulated-phenotype-file", type=str)
 @click.argument("old_config_file", type=click.Path(exists=True))
 @click.argument("new_config_file", type=click.Path())

--- a/deeprvat/seed_gene_discovery/seed_gene_discovery.py
+++ b/deeprvat/seed_gene_discovery/seed_gene_discovery.py
@@ -9,11 +9,14 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
 import click
+import dask.dataframe as dd
 import numpy as np
 import pandas as pd
 import yaml
+import random
 from scipy.stats import beta
 from scipy.sparse import coo_matrix, spmatrix
+from statsmodels.stats.multitest import fdrcorrection
 from torch.utils.data import DataLoader, Dataset
 from tqdm import tqdm
 

--- a/deeprvat_env.yaml
+++ b/deeprvat_env.yaml
@@ -31,6 +31,6 @@ dependencies:
   - zarr=2.13
   - Cython=0.29
   - pip=23.0.1
-  - plotnine=0.12.2
+  - plotnine=0.10.1
   - pip:
     - git+https://github.com/HealthML/seak@v0.4.3

--- a/deeprvat_env.yaml
+++ b/deeprvat_env.yaml
@@ -31,5 +31,6 @@ dependencies:
   - zarr=2.13
   - Cython=0.29
   - pip=23.0.1
+  - plotnine=0.12.2
   - pip:
     - git+https://github.com/HealthML/seak@v0.4.3

--- a/deeprvat_env_no_gpu.yml
+++ b/deeprvat_env_no_gpu.yml
@@ -28,5 +28,6 @@ dependencies:
   - zarr=2.13
   - Cython=0.29
   - pip=23.1.2
+  - plotnine=0.12.2
   - pip:
     - git+https://github.com/HealthML/seak@v0.4.3

--- a/deeprvat_env_no_gpu.yml
+++ b/deeprvat_env_no_gpu.yml
@@ -28,6 +28,6 @@ dependencies:
   - zarr=2.13
   - Cython=0.29
   - pip=23.1.2
-  - plotnine=0.12.2
+  - plotnine=0.10.1
   - pip:
     - git+https://github.com/HealthML/seak@v0.4.3


### PR DESCRIPTION
This PR updates the example data and `seed gene discovery pipeline` so that they work together.


- `is_plof` was added to` annontations.parquet` using this code:

```python
anno = pd.read_parquet("annotations.parquet")
if 'is_plof' not in anno.columns:
    is_plof = pd.Series([False] * len(anno), index=anno.index)
    for c in ('splice_acceptor_variant', 'splice_donor_variant',
              'frameshift_variant', 'stop_gained', 'stop_lost', 'start_lost'):
        is_plof |= (anno[f'Consequence_{c}'] > 0)

anno["is_plof"] = is_plof
anno.to_parquet("annotations.parquet")
```

- All references to `genes.parquet` were changed to the correct name `protein_coding_genes.parquet`

- References to `combined_UKB_NFE_AF` was changed to `MAF`

- `plotnine` was added as a dependency to the deeprvat environment.

- README was updated to reflect changes

- The seed gene discovery pipeline was added to the github actions pipeline test runs 


## Testing

Set up a deeprvat env from the `deeprvat_env.yaml` file:
```
mamba env create -n deeprvat -f deeprvat_env.yaml 
```
-  Activate the environment: `mamba activate deeprvat`
-  Install the `deeprvat` package: `pip install -e .`
-  Setup the example repo:

```shell
mkdir example
cd example
ln -s [path_to_deeprvat]/example/* .
cp [path_to_deeprvat]/deeprvat/seed_gene_discovery/config.yaml  .

```
(Replace `[path_to_deeprvat]` with the path to your clone of the repository.)

- Run the pipeline with the example data:
```shell
snakemake -j 1 --snakefile [path_to_deeprvat]/pipelines/seed_gene_discovery.snakefile
```