### PR TITLE
Remove sample sorting from preprocessing

### DIFF
--- a/deeprvat/preprocessing/preprocess.py
+++ b/deeprvat/preprocessing/preprocess.py
@@ -227,6 +227,8 @@ def process_sparse_gt(
         else:
             logging.info(f"Found no samples to exclude in {exclude_samples}")
 
+    samples = list(samples)
+
     logging.info("Processing sparse GT files by chromosome")
     total_calls_dropped = 0
     variant_groups = variants.groupby("chrom")

--- a/deeprvat/preprocessing/preprocess.py
+++ b/deeprvat/preprocessing/preprocess.py
@@ -227,9 +227,6 @@ def process_sparse_gt(
         else:
             logging.info(f"Found no samples to exclude in {exclude_samples}")
 
-    # Assumes only numeric sample names
-    samples = sorted([s for s in samples if int(s) > 0])
-
     logging.info("Processing sparse GT files by chromosome")
     total_calls_dropped = 0
     variant_groups = variants.groupby("chrom")


### PR DESCRIPTION
# What
Removes the sorting of samples in `process_sparse_gt` this step was used for shuffling samples but assumed that the sample names were only numeric.