### PR TITLE
Save chunk shape after dropping duplicates

### DIFF
--- a/deeprvat/annotations/annotations.py
+++ b/deeprvat/annotations/annotations.py
@@ -934,8 +934,8 @@ def process_chunk_addids(chunk, variants):
         }
     )
     key_cols = ["chrom", "pos", "ref", "alt"]
-    chunk_shape = chunk.shape
     chunk.drop_duplicates(subset=key_cols, inplace=True)
+    chunk_shape = chunk.shape
     chunk = pd.merge(chunk, variants, on=key_cols, how="left", validate="1:1")
 
     try:


### PR DESCRIPTION
# What
This PR solves an issue in the `process_chunk_addids` in the annotation pipeline.
Currently if there are any duplicates in the chunk the assert will fail since we save the chunk shape before dropping the duplicates.

The assert is meant to check the merging of the chunk and the variants and not check for duplicates in the chunk.

![image](https://github.com/PMBio/deeprvat/assets/135472/f3d1713e-1c34-4e3b-b831-8f9c19d81454)
