### PR TITLE
Point docs to RTD

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,12 +37,12 @@ If you are running on an computing cluster, you will need a [profile](https://gi
 
 ### Run the preprocessing pipeline on VCF files
 
-Instructions [here](https://github.com/PMBio/deeprvat/blob/main/docs/preprocessing.md)
+Instructions [here](https://deeprvat.readthedocs.io/en/latest/preprocessing.html)
 
 
 ### Annotate variants
 
-Instructions [here](https://github.com/PMBio/deeprvat/blob/main/docs/annotations.md)
+Instructions [here](https://deeprvat.readthedocs.io/en/latest/annotations.html)
 
 
 

--- a/docs/annotations.md
+++ b/docs/annotations.md
@@ -75,7 +75,7 @@ The config above would use the following directory structure:
 
 ```
 
-Bcf files created by the [preprocessing pipeline](https://github.com/PMBio/deeprvat/blob/Annotations/deeprvat/preprocessing/README.md) are used as input data. 
+Bcf files created by the [preprocessing pipeline](preprocessing.md) are used as input data. 
 The pipeline also uses the variant.tsv file as well as the reference file from the preprocesing pipeline. 
 The pipeline beginns by installing the repositories needed for the annotations, it will automatically install all repositories in the `repo_dir` folder that can be specified in the config file relative to the annotation working directory.
 The text file mapping blocks to chromosomes is stored in `metadata` folder. The output is stored in the `output_dir/annotations` folder and any temporary files in the `tmp` subfolder. All repositories used including VEP with its corresponding cache as well as plugins are stored in `repo_dir/ensempl-vep`.

--- a/docs/seed_gene_discovery.md
+++ b/docs/seed_gene_discovery.md
@@ -6,7 +6,7 @@ To run the pipeline, an experiment directory with the `config.yaml` has to be cr
 
 ## Input data
 
-The experiment directory in addition requires to have the same input data as specified for [DeepRVAT](https://github.com/PMBio/deeprvat/tree/main/README.md), including
+The experiment directory in addition requires to have the same input data as specified for [DeepRVAT](usage.md), including
 - `annotations.parquet`
 - `protein_coding_genes.parquet`
 - `genotypes.h5`
@@ -23,7 +23,7 @@ The `annotations.parquet` data frame should have the following columns:
 
 ### Run the seed gene discovery pipeline with example data  
 
-Create the conda environment and activate it, (instructions can be found in the [DeepRVAT README](https://github.com/PMBio/deeprvat/tree/main/README.md) )
+Create the conda environment and activate it, (instructions can be found here [DeepRVAT instructions](usage.md) )
 
 
 ```


### PR DESCRIPTION
Update links in main readme to point to https://deeprvat.readthedocs.io.

Also fixes a few internal links in the docs that pointed to github.