### PR TITLE
fixed bugs in the annotation pipeline based on issues #61, #62 and #63.

### DIFF
--- a/deeprvat/annotations/annotations.py
+++ b/deeprvat/annotations/annotations.py
@@ -1899,6 +1899,15 @@ def process_vep(
         "Consequence_inframe_deletion",
         "Consequence_missense_variant",
         "Consequence_non_coding_transcript_variant",
+        "Consequence_TFBS_amplification",
+        "Consequence_coding_transcript_variant",
+        "Consequence_feature_elongation",
+        "Consequence_feature_truncation",
+        "Consequence_regulatory_region_ablation",
+        "Consequence_regulatory_region_amplification",
+        "Consequence_sequence_variant",
+        "Consequence_transcript_ablation",
+        "Consequence_transcript_amplification"
     ]
     all_consequences = list(set(all_consequences))
     mask = pd.DataFrame(

--- a/deeprvat/annotations/annotations.py
+++ b/deeprvat/annotations/annotations.py
@@ -1907,7 +1907,7 @@ def process_vep(
         "Consequence_regulatory_region_amplification",
         "Consequence_sequence_variant",
         "Consequence_transcript_ablation",
-        "Consequence_transcript_amplification"
+        "Consequence_transcript_amplification",
     ]
     all_consequences = list(set(all_consequences))
     mask = pd.DataFrame(

--- a/pipelines/resources/absplice_download.snakefile
+++ b/pipelines/resources/absplice_download.snakefile
@@ -126,7 +126,7 @@ if absplice_main_conf['use_rocksdb'] == True:
         conda:
             f"./environment_spliceai_rocksdb.yaml"
         output:
-            spliceai_rocksdb = Path(absplice_download_dir) / directory(config_download['spliceai_rocksdb'][genome])
+            spliceai_rocksdb = directory(Path(absplice_download_dir) / config_download['spliceai_rocksdb'][genome])
         shell:
             "spliceai_rocksdb_download --version {params.version} --db_path {output.spliceai_rocksdb} --chromosome {wildcards.chromosome}"
     list_outputs.append(

--- a/pipelines/resources/environment_spliceai_rocksdb.yaml
+++ b/pipelines/resources/environment_spliceai_rocksdb.yaml
@@ -19,4 +19,4 @@ dependencies:
   - bioconda::spliceai==1.3.1
   - bioconda::cyvcf2==0.30.16
   - pip:
-    - git+https://github.com/gagneurlab/spliceai_rocksdb.git@0.0.1
+    - git+https://github.com/gagneurlab/spliceai_rocksdb.git@v1.0.0


### PR DESCRIPTION
# What

This PR is addressing the three open issues #61, #62 and #63 posted by user @Jonas-B-Frank, namely
- a mistake in the output of `rule download_rocksdb` in `absplice_download.snakefile`
-  a nonfunctional version tag in `environment_spliceai_rocksdb.yaml`
- missing consequences considered in the VEP output
# Testing
To test the pipeline, it has to be run locally and the output has to be checked. 

## Test scenarios
As described in the documentation for the annotation pipeline
