### PR TITLE
Doc graphics generation script

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -14,6 +14,14 @@ help:
 
 .PHONY: help Makefile
 
+
+
+.PHONY: check-codestyle
+generate-doc-graphs:
+	bash generate-doc-graphs.sh
+
+
+
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
 %: Makefile

--- a/docs/generate-doc-graphs.sh
+++ b/docs/generate-doc-graphs.sh
@@ -7,6 +7,10 @@ CONFIG_DIR="$PIPELINE_DIR/config"
 WORK_DIR="$SCRIPT_PATH/../example"
 STATIC_DIR="$SCRIPT_PATH/_static"
 
+if ! command -v "snakemake" &> /dev/null; then
+    echo "Please install snakemake (did you forget to activate the conda env?)"
+    exit 1
+fi
 
 check_result_file(){
   file_path="$1"

--- a/docs/generate-doc-graphs.sh
+++ b/docs/generate-doc-graphs.sh
@@ -8,6 +8,19 @@ WORK_DIR="$SCRIPT_PATH/../example"
 STATIC_DIR="$SCRIPT_PATH/_static"
 
 
+check_result_file(){
+  file_path="$1"
+  if [ -e "$file_path" ]; then
+      if [ -s "$file_path" ]; then
+          echo "Ok graph exists :)"
+      else
+          # Remove the file
+          rm "$file_path"
+          echo "Fail: Graph was empty, removed."
+      fi
+  fi
+}
+
 generate_rule_graph() {
   SNAKEFILE="$PIPELINE_DIR/$1"
   DIRECTORY="$2"
@@ -19,7 +32,7 @@ generate_rule_graph() {
   snakemake -n --snakefile "$SNAKEFILE" --directory "$DIRECTORY" --configfile "$CONFIG" --forceall --rulegraph \
     | sed -n '/digraph/,$p' | awk '!/color=/{gsub(/color = "[^"]+",/, "");} {gsub(/,$/, "");} 1' | awk '{$1=$1}1' \
     | dot -Tsvg > "$OUTPUT_FILE"
-
+  check_result_file "$OUTPUT_FILE"
   echo -e "---------\n"
 }
 
@@ -33,6 +46,7 @@ generate_dag_graph() {
   echo "Generating dag graph: $OUTPUT_FILE"
   snakemake -n --snakefile "$SNAKEFILE" --directory "$DIRECTORY" --configfile "$CONFIG" --forceall --dag \
     | sed -n '/digraph/,$p' | dot -Tsvg > "$OUTPUT_FILE"
+  check_result_file "$OUTPUT_FILE"
 }
 
 

--- a/docs/generate-doc-graphs.sh
+++ b/docs/generate-doc-graphs.sh
@@ -67,3 +67,6 @@ generate_rule_graph "seed_gene_discovery.snakefile" "$WORK_DIR" "$WORK_DIR/confi
 generate_rule_graph "training_association_testing.snakefile" "$WORK_DIR" "$WORK_DIR/config.yaml"
 
 generate_rule_graph "training_association_testing_regenie.snakefile" "$WORK_DIR" "$WORK_DIR/config.yaml"
+
+
+echo "Done!"

--- a/docs/generate-doc-graphs.sh
+++ b/docs/generate-doc-graphs.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+SCRIPT_PATH="$( cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
+
+
+generate_rule_graph() {
+  SNAKEFILE="$1"
+  DIRECTORY="$2"
+  CONFIG="$3"
+  OUTPUT_FILE="$4"
+
+  echo "Generating rule graph: $OUTPUT_FILE"
+
+
+  snakemake -n --snakefile "$SNAKEFILE" --directory "$DIRECTORY" --configfile "$CONFIG" --forceall --rulegraph \
+    | tail -n +2  | awk '!/color=/{gsub(/color = "[^"]+",/, "");} {gsub(/,$/, "");} 1' | awk '{$1=$1}1' \
+    | dot -Tsvg > "$OUTPUT_FILE"
+}
+
+
+generate_dag_graph() {
+  SNAKEFILE="$1"
+  DIRECTORY="$2"
+  CONFIG="$3"
+  OUTPUT_FILE="$4"
+  echo "Generating dag graph: $OUTPUT_FILE"
+  snakemake -n --snakefile "$SNAKEFILE" --directory "$DIRECTORY" --configfile "$CONFIG" --forceall --dag \
+    | tail -n +2 | dot -Tsvg > "$OUTPUT_FILE"
+}
+
+
+
+
+PIPELINE_DIR="$SCRIPT_PATH/../pipelines"
+CONFIG_DIR="$PIPELINE_DIR/config"
+WORK_DIR="$SCRIPT_PATH/../example"
+STATIC_DIR="$SCRIPT_PATH/_static"
+
+generate_rule_graph "$PIPELINE_DIR/preprocess_with_qc.snakefile" "$WORK_DIR/preprocess" "$CONFIG_DIR/deeprvat_preprocess_config.yaml" "$STATIC_DIR/preprocess_rulegraph_with_qc.svg"
+generate_rule_graph "$PIPELINE_DIR/preprocess_no_qc.snakefile" "$WORK_DIR/preprocess" "$CONFIG_DIR/deeprvat_preprocess_config.yaml" "$STATIC_DIR/preprocess_rulegraph_no_qc.svg"
+
+generate_rule_graph "$PIPELINE_DIR/annotations.snakefile"  "$WORK_DIR/annotations" "$CONFIG_DIR/deeprvat_annotation_config.yaml" "$STATIC_DIR/annotation_rulegraph.svg"
+generate_dag_graph "$PIPELINE_DIR/annotations.snakefile"  "$WORK_DIR/annotations" "$CONFIG_DIR/deeprvat_annotation_config.yaml" "$STATIC_DIR/annotation_pipeline_dag.svg"
+

--- a/docs/generate-doc-graphs.sh
+++ b/docs/generate-doc-graphs.sh
@@ -2,43 +2,54 @@
 
 SCRIPT_PATH="$( cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
 
-
-generate_rule_graph() {
-  SNAKEFILE="$1"
-  DIRECTORY="$2"
-  CONFIG="$3"
-  OUTPUT_FILE="$4"
-
-  echo "Generating rule graph: $OUTPUT_FILE"
-
-
-  snakemake -n --snakefile "$SNAKEFILE" --directory "$DIRECTORY" --configfile "$CONFIG" --forceall --rulegraph \
-    | tail -n +2  | awk '!/color=/{gsub(/color = "[^"]+",/, "");} {gsub(/,$/, "");} 1' | awk '{$1=$1}1' \
-    | dot -Tsvg > "$OUTPUT_FILE"
-}
-
-
-generate_dag_graph() {
-  SNAKEFILE="$1"
-  DIRECTORY="$2"
-  CONFIG="$3"
-  OUTPUT_FILE="$4"
-  echo "Generating dag graph: $OUTPUT_FILE"
-  snakemake -n --snakefile "$SNAKEFILE" --directory "$DIRECTORY" --configfile "$CONFIG" --forceall --dag \
-    | tail -n +2 | dot -Tsvg > "$OUTPUT_FILE"
-}
-
-
-
-
 PIPELINE_DIR="$SCRIPT_PATH/../pipelines"
 CONFIG_DIR="$PIPELINE_DIR/config"
 WORK_DIR="$SCRIPT_PATH/../example"
 STATIC_DIR="$SCRIPT_PATH/_static"
 
-generate_rule_graph "$PIPELINE_DIR/preprocess_with_qc.snakefile" "$WORK_DIR/preprocess" "$CONFIG_DIR/deeprvat_preprocess_config.yaml" "$STATIC_DIR/preprocess_rulegraph_with_qc.svg"
-generate_rule_graph "$PIPELINE_DIR/preprocess_no_qc.snakefile" "$WORK_DIR/preprocess" "$CONFIG_DIR/deeprvat_preprocess_config.yaml" "$STATIC_DIR/preprocess_rulegraph_no_qc.svg"
 
-generate_rule_graph "$PIPELINE_DIR/annotations.snakefile"  "$WORK_DIR/annotations" "$CONFIG_DIR/deeprvat_annotation_config.yaml" "$STATIC_DIR/annotation_rulegraph.svg"
-generate_dag_graph "$PIPELINE_DIR/annotations.snakefile"  "$WORK_DIR/annotations" "$CONFIG_DIR/deeprvat_annotation_config.yaml" "$STATIC_DIR/annotation_pipeline_dag.svg"
+generate_rule_graph() {
+  SNAKEFILE="$PIPELINE_DIR/$1"
+  DIRECTORY="$2"
+  CONFIG="$3"
+  OUTPUT_FILE="$STATIC_DIR/$(basename $SNAKEFILE |cut -f 1 -d'.')_rulegraph.svg"
 
+  echo "Generating rule graph: $OUTPUT_FILE"
+
+  snakemake -n --snakefile "$SNAKEFILE" --directory "$DIRECTORY" --configfile "$CONFIG" --forceall --rulegraph \
+    | sed -n '/digraph/,$p' | awk '!/color=/{gsub(/color = "[^"]+",/, "");} {gsub(/,$/, "");} 1' | awk '{$1=$1}1' \
+    | dot -Tsvg > "$OUTPUT_FILE"
+
+  echo -e "---------\n"
+}
+
+
+generate_dag_graph() {
+  SNAKEFILE="$PIPELINE_DIR/$1"
+  DIRECTORY="$2"
+  CONFIG="$3"
+  OUTPUT_FILE="$STATIC_DIR/$(basename $SNAKEFILE |cut -f 1 -d'.')_dag.svg"
+
+  echo "Generating dag graph: $OUTPUT_FILE"
+  snakemake -n --snakefile "$SNAKEFILE" --directory "$DIRECTORY" --configfile "$CONFIG" --forceall --dag \
+    | sed -n '/digraph/,$p' | dot -Tsvg > "$OUTPUT_FILE"
+}
+
+
+generate_rule_graph "preprocess_with_qc.snakefile" "$WORK_DIR/preprocess" "$CONFIG_DIR/deeprvat_preprocess_config.yaml"
+generate_rule_graph "preprocess_no_qc.snakefile" "$WORK_DIR/preprocess" "$CONFIG_DIR/deeprvat_preprocess_config.yaml"
+
+generate_rule_graph "annotations.snakefile"  "$WORK_DIR/annotations" "$CONFIG_DIR/deeprvat_annotation_config.yaml"
+generate_dag_graph "annotations.snakefile"  "$WORK_DIR/annotations" "$CONFIG_DIR/deeprvat_annotation_config.yaml"
+
+generate_rule_graph "association_testing_pretrained.snakefile" "$WORK_DIR" "$WORK_DIR/config.yaml"
+
+generate_rule_graph "association_testing_pretrained_regenie.snakefile" "$WORK_DIR" "$WORK_DIR/config.yaml"
+
+generate_rule_graph "run_training.snakefile" "$WORK_DIR" "$WORK_DIR/config.yaml"
+
+generate_rule_graph "seed_gene_discovery.snakefile" "$WORK_DIR" "$WORK_DIR/config.yaml"
+
+generate_rule_graph "training_association_testing.snakefile" "$WORK_DIR" "$WORK_DIR/config.yaml"
+
+generate_rule_graph "training_association_testing_regenie.snakefile" "$WORK_DIR" "$WORK_DIR/config.yaml"

--- a/docs/generate-doc-graphs.sh
+++ b/docs/generate-doc-graphs.sh
@@ -12,7 +12,7 @@ generate_rule_graph() {
   SNAKEFILE="$PIPELINE_DIR/$1"
   DIRECTORY="$2"
   CONFIG="$3"
-  OUTPUT_FILE="$STATIC_DIR/$(basename $SNAKEFILE |cut -f 1 -d'.')_rulegraph.svg"
+  OUTPUT_FILE="$STATIC_DIR/$(basename "$SNAKEFILE" |cut -f 1 -d'.')_rulegraph.svg"
 
   echo "Generating rule graph: $OUTPUT_FILE"
 
@@ -28,7 +28,7 @@ generate_dag_graph() {
   SNAKEFILE="$PIPELINE_DIR/$1"
   DIRECTORY="$2"
   CONFIG="$3"
-  OUTPUT_FILE="$STATIC_DIR/$(basename $SNAKEFILE |cut -f 1 -d'.')_dag.svg"
+  OUTPUT_FILE="$STATIC_DIR/$(basename "$SNAKEFILE" |cut -f 1 -d'.')_dag.svg"
 
   echo "Generating dag graph: $OUTPUT_FILE"
   snakemake -n --snakefile "$SNAKEFILE" --directory "$DIRECTORY" --configfile "$CONFIG" --forceall --dag \

--- a/docs/generate-doc-graphs.sh
+++ b/docs/generate-doc-graphs.sh
@@ -73,5 +73,4 @@ generate_rule_graph "training_association_testing.snakefile" "$WORK_DIR" "$WORK_
 
 generate_rule_graph "training_association_testing_regenie.snakefile" "$WORK_DIR" "$WORK_DIR/config.yaml"
 
-
 echo "Done!"

--- a/docs/generate-doc-graphs.sh
+++ b/docs/generate-doc-graphs.sh
@@ -33,6 +33,7 @@ generate_rule_graph() {
 
   echo "Generating rule graph: $OUTPUT_FILE"
 
+  # The awk part makes sure that the nodes are all the same color
   snakemake -n --snakefile "$SNAKEFILE" --directory "$DIRECTORY" --configfile "$CONFIG" --forceall --rulegraph \
     | sed -n '/digraph/,$p' | awk '!/color=/{gsub(/color = "[^"]+",/, "");} {gsub(/,$/, "");} 1' | awk '{$1=$1}1' \
     | dot -Tsvg > "$OUTPUT_FILE"


### PR DESCRIPTION
# What

This PR adds a new script to the docs make file that generates rulegraphs for our pipelines.
The script uses `snakemake --rulegraph` togheter with graphviz to create svg files that get written to the _static folder so they can be used in the docs.

# Testing
Clone the repo and cd into the docs run the make command and check that the svg files are created. (note that some of the pipelines fails to generate graphs now without adding tweaking.)

`make generate-doc-graphs`

```bash
$ make generate-doc-graphs
bash generate-doc-graphs.sh
Generating rule graph: /Users/b260-admin/code/dkfz/deeprvat/docs/_static/preprocess_with_qc_rulegraph.svg
Building DAG of jobs...
Ok graph exists :)
---------

Generating rule graph: /Users/b260-admin/code/dkfz/deeprvat/docs/_static/preprocess_no_qc_rulegraph.svg
Building DAG of jobs...
Ok graph exists :)
---------

Generating rule graph: /Users/b260-admin/code/dkfz/deeprvat/docs/_static/annotations_rulegraph.svg
Building DAG of jobs...
Ok graph exists :)
---------

Generating dag graph: /Users/b260-admin/code/dkfz/deeprvat/docs/_static/annotations_dag.svg
Building DAG of jobs...
Ok graph exists :)
```

![image](https://github.com/PMBio/deeprvat/assets/135472/5b1f8ed1-b2a4-4133-b787-582df172fd2c)
