### PR TITLE
add association_only flag into config rule

### DIFF
--- a/pipelines/cv_training/cv_training.snakefile
+++ b/pipelines/cv_training/cv_training.snakefile
@@ -97,4 +97,5 @@ use rule config from deeprvat_workflow as deeprvat_config with:
             for b in input.baseline
         ])  if wildcards.phenotype in training_phenotypes else ' ',
         baseline_out = lambda wildcards: f'--baseline-results-out cv_split{wildcards.cv_split}/deeprvat/{wildcards.phenotype}/deeprvat/baseline_results.parquet' if wildcards.phenotype in training_phenotypes else ' ',
-        seed_genes_out = lambda wildcards: f'--seed-genes-out cv_split{wildcards.cv_split}/deeprvat/{wildcards.phenotype}/deeprvat/seed_genes.parquet' if wildcards.phenotype in training_phenotypes else ' '
+        seed_genes_out = lambda wildcards: f'--seed-genes-out cv_split{wildcards.cv_split}/deeprvat/{wildcards.phenotype}/deeprvat/seed_genes.parquet' if wildcards.phenotype in training_phenotypes else ' ',
+        association_only = lambda wildcards: f'--association-only' if wildcards.phenotype not in training_phenotypes else ' '

--- a/pipelines/training/config.snakefile
+++ b/pipelines/training/config.snakefile
@@ -33,11 +33,15 @@ rule config:
         baseline_out=lambda wildcards: f"--baseline-results-out  {wildcards.phenotype}/deeprvat/baseline_results.parquet"
         if wildcards.phenotype in training_phenotypes
         else " ",
+        association_only=lambda wildcards: f"--association-only"
+        if wildcards.phenotype not in training_phenotypes
+        else " ",
     shell:
         (
             "deeprvat_config update-config "
             "--phenotype {wildcards.phenotype} "
-            "{params.baseline_results}"
+            "{params.association_only} "
+            "{params.baseline_results} "
             "{params.baseline_out} "
             "{params.seed_genes_out} "
             "{input.config} "


### PR DESCRIPTION
# What
Fixes the config rule in the snakemake pipelines to include the association_only flag, necessary for update-config function in config.py. Fixes both basic and cv-split training setups.

# Testing
Pytests completed and successfully ran on sample data.