### PR TITLE
Update environment_spliceai_rocksdb.yaml

### DIFF
--- a/pipelines/resources/environment_spliceai_rocksdb.yaml
+++ b/pipelines/resources/environment_spliceai_rocksdb.yaml
@@ -19,4 +19,4 @@ dependencies:
   - bioconda::spliceai==1.3.1
   - bioconda::cyvcf2==0.30.16
   - pip:
-    - git+https://github.com/gagneurlab/spliceai_rocksdb.git
+    - git+https://github.com/gagneurlab/spliceai_rocksdb.git@3c40d6e61b19e907e802c979c76d52ea5c41c1d5

--- a/pipelines/resources/environment_spliceai_rocksdb.yaml
+++ b/pipelines/resources/environment_spliceai_rocksdb.yaml
@@ -19,4 +19,4 @@ dependencies:
   - bioconda::spliceai==1.3.1
   - bioconda::cyvcf2==0.30.16
   - pip:
-    - git+https://github.com/gagneurlab/spliceai_rocksdb.git@v1.0.0
+    - git+https://github.com/gagneurlab/spliceai_rocksdb.git


### PR DESCRIPTION
removed version tag from spliceai_rockdb git repo

# What

Removed version tag from spliceai_rockdb git repo inside environment_spliceai_rocksdb yaml file. 
Since this verson tag caused trouble in the absplice pipeline, removing this tag constitutes a hotfix for the annnotation pipeline, until a better solution is found. 

# Testing
clone repo and run pipeline as described in the docs

