### PR TITLE
Change GitHub action runner to ubuntu-latest

### DIFF
--- a/.github/workflows/autoblack_pull_request.yml
+++ b/.github/workflows/autoblack_pull_request.yml
@@ -7,7 +7,7 @@ name: autoblack_pull_request
 on: [ pull_request ]
 jobs:
   black-code:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/autoblack_pull_request.yml
+++ b/.github/workflows/autoblack_pull_request.yml
@@ -7,7 +7,7 @@ name: autoblack_pull_request
 on: [ pull_request ]
 jobs:
   black-code:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/docs-tests.yml
+++ b/.github/workflows/docs-tests.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   docs-build:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v4
     - uses: ammaraskar/sphinx-action@0.4
@@ -14,7 +14,7 @@ jobs:
         docs-folder: "docs/"
 
   docs-link-check:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v4
     - uses: ammaraskar/sphinx-action@0.4

--- a/.github/workflows/docs-tests.yml
+++ b/.github/workflows/docs-tests.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   docs-build:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
     - uses: ammaraskar/sphinx-action@0.4
@@ -14,7 +14,7 @@ jobs:
         docs-folder: "docs/"
 
   docs-link-check:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
     - uses: ammaraskar/sphinx-action@0.4

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -4,7 +4,7 @@ on: [ push ]
 
 jobs:
   DeepRVAT-Pipeline-Smoke-Tests:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Check out repository code
         uses: actions/checkout@v4
@@ -37,7 +37,7 @@ jobs:
         shell: micromamba-shell {0}
 
   DeepRVAT-Pipeline-Tests:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     needs: DeepRVAT-Pipeline-Smoke-Tests
     steps:
       - name: Check out repository code
@@ -79,7 +79,7 @@ jobs:
 
 
   DeepRVAT-Preprocessing-Pipeline-Smoke-Tests:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Check out repository code
         uses: actions/checkout@v4
@@ -112,7 +112,7 @@ jobs:
 
 
   DeepRVAT-Annotation-Pipeline-Smoke-Tests:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Check out repository code
         uses: actions/checkout@v4
@@ -131,7 +131,7 @@ jobs:
 
 
   DeepRVAT-Preprocessing-Pipeline-Tests-No-QC:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     needs: DeepRVAT-Preprocessing-Pipeline-Smoke-Tests
     steps:
       - name: Check out repository code
@@ -171,7 +171,7 @@ jobs:
 
 
   DeepRVAT-Preprocessing-Pipeline-Tests-With-QC:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     needs: DeepRVAT-Preprocessing-Pipeline-Smoke-Tests
     steps:
 

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -4,7 +4,7 @@ on: [ push ]
 
 jobs:
   DeepRVAT-Pipeline-Smoke-Tests:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - name: Check out repository code
         uses: actions/checkout@v4
@@ -37,7 +37,7 @@ jobs:
         shell: micromamba-shell {0}
 
   DeepRVAT-Pipeline-Tests:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     needs: DeepRVAT-Pipeline-Smoke-Tests
     steps:
       - name: Check out repository code
@@ -79,7 +79,7 @@ jobs:
 
 
   DeepRVAT-Preprocessing-Pipeline-Smoke-Tests:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - name: Check out repository code
         uses: actions/checkout@v4
@@ -112,7 +112,7 @@ jobs:
 
 
   DeepRVAT-Annotation-Pipeline-Smoke-Tests:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - name: Check out repository code
         uses: actions/checkout@v4
@@ -131,7 +131,7 @@ jobs:
 
 
   DeepRVAT-Preprocessing-Pipeline-Tests-No-QC:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     needs: DeepRVAT-Preprocessing-Pipeline-Smoke-Tests
     steps:
       - name: Check out repository code
@@ -171,7 +171,7 @@ jobs:
 
 
   DeepRVAT-Preprocessing-Pipeline-Tests-With-QC:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     needs: DeepRVAT-Preprocessing-Pipeline-Smoke-Tests
     steps:
 

--- a/.github/workflows/test-runner.yml
+++ b/.github/workflows/test-runner.yml
@@ -4,7 +4,7 @@ on: [ push ]
 
 jobs:
   DeepRVAT-Tests-Runner:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - name: Check out repository code
         uses: actions/checkout@v4
@@ -24,7 +24,7 @@ jobs:
         shell: micromamba-shell {0}
 
   DeepRVAT-Tests-Runner-Preprocessing:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - name: Check out repository code
         uses: actions/checkout@v4
@@ -45,7 +45,7 @@ jobs:
         shell: micromamba-shell {0}
 
   DeepRVAT-Tests-Runner-Annotations:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - name: Check out repository code
         uses: actions/checkout@v4

--- a/.github/workflows/test-runner.yml
+++ b/.github/workflows/test-runner.yml
@@ -4,7 +4,7 @@ on: [ push ]
 
 jobs:
   DeepRVAT-Tests-Runner:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Check out repository code
         uses: actions/checkout@v4
@@ -24,7 +24,7 @@ jobs:
         shell: micromamba-shell {0}
 
   DeepRVAT-Tests-Runner-Preprocessing:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Check out repository code
         uses: actions/checkout@v4
@@ -45,7 +45,7 @@ jobs:
         shell: micromamba-shell {0}
 
   DeepRVAT-Tests-Runner-Annotations:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Check out repository code
         uses: actions/checkout@v4

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,7 +7,7 @@ version: 2
 
 # Set the OS, Python version and other tools you might need
 build:
-  os: ubuntu-22.04
+  os: ubuntu-latest
   tools:
     python: "3.12"
 

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,7 +7,7 @@ version: 2
 
 # Set the OS, Python version and other tools you might need
 build:
-  os: ubuntu-latest
+  os: ubuntu-lts-latest
   tools:
     python: "3.12"
 


### PR DESCRIPTION
# What

Reverts the changed runner base images from 24.04 to ubuntu-latest.
24.04 was not deployed yet so no actions started.

# Testing
The actions should run now.