### PR TITLE
Create author list dynamically in docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,6 +76,7 @@ instance/
 
 # Sphinx documentation
 docs/_build/
+docs/apidocs/
 
 # PyBuilder
 .pybuilder/

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -7,9 +7,9 @@
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
 from datetime import datetime
+from importlib.metadata import version
 from pathlib import Path
 
-import pkg_resources
 import yaml
 
 
@@ -29,7 +29,7 @@ author_list = get_authors(cff_file=cff_path)
 project = "DeepRVAT"
 copyright = f"{datetime.now().year}, {author_list}"
 author = f"{author_list}"
-version = pkg_resources.require("DeepRVAT")[0].version
+version = version("deeprvat")
 release = version
 
 # -- General configuration ---------------------------------------------------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -7,7 +7,6 @@
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
 from datetime import datetime
-from importlib.metadata import version
 from pathlib import Path
 
 import yaml
@@ -22,14 +21,13 @@ def get_authors(cff_file):
 
 
 cff_path = Path(__file__).parent.resolve() / "../CITATION.cff"
-
 author_list = get_authors(cff_file=cff_path)
 
 
 project = "DeepRVAT"
 copyright = f"{datetime.now().year}, {author_list}"
 author = f"{author_list}"
-version = version("deeprvat")
+version = "0.1.0"
 release = version
 
 # -- General configuration ---------------------------------------------------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -7,11 +7,29 @@
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
 from datetime import datetime
+from pathlib import Path
+
+import pkg_resources
+import yaml
+
+
+def get_authors(cff_file):
+    with open(cff_file) as cff_data:
+        authors = yaml.safe_load(cff_data).get("authors")
+        return ", ".join(
+            [f"{a['family-names']}, {a['given-names'][0]}." for a in authors]
+        )
+
+
+cff_path = Path(__file__).parent.resolve() / "../CITATION.cff"
+
+author_list = get_authors(cff_file=cff_path)
+
 
 project = "DeepRVAT"
-copyright = f"{datetime.now().year}, Clarke, B., Holtkamp, E., Öztürk, H., Mück, M., Wahlberg, M., Meyer, K., Brechtmann, F., Hölzlwimmer, F. R., Gagneur, J., & Stegle, O"
-author = "Clarke, B., Holtkamp, E., Öztürk, H., Mück, M., Wahlberg, M., Meyer, K., Brechtmann, F., Hölzlwimmer, F. R., Gagneur, J., & Stegle, O"
-version = "0.1.0"
+copyright = f"{datetime.now().year}, {author_list}"
+author = f"{author_list}"
+version = pkg_resources.require("DeepRVAT")[0].version
 release = version
 
 # -- General configuration ---------------------------------------------------

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -5,3 +5,6 @@ astroid==2.15.8
 sphinx-copybutton==0.5.2
 sphinx-rtd-theme==1.3.0
 PyYAML==6.0.1
+
+# Install the DeepRVAT package
+-e .

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,3 +4,4 @@ sphinx-autodoc2==0.4.2
 astroid==2.15.8
 sphinx-copybutton==0.5.2
 sphinx-rtd-theme==1.3.0
+PyYAML==6.0.1

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -5,6 +5,3 @@ astroid==2.15.8
 sphinx-copybutton==0.5.2
 sphinx-rtd-theme==1.3.0
 PyYAML==6.0.1
-
-# Install the DeepRVAT package
--e .


### PR DESCRIPTION
# What

This PR updates the doc build process so that we add the authors to the doc automatically from the `citations.cff` file, so we don't have to update them i 3 separate places.

# Testing
To test this pr you can first build the docs and look at the author list in the docs:

`make html && open _build/html/index.html`

![Screenshot 2024-05-21 at 12 18 39](https://github.com/PMBio/deeprvat/assets/135472/dc35f846-dbe3-42c0-a219-7e7306feff05)

Then try adding a new author to the citations.cff example:
```yaml
...
  - given-names: Oliver
    family-names: Stegle
    orcid: 'https://orcid.org/0000-0002-8818-7193'
  - given-names: John
    family-names: Doe
    orcid: 'https://orcid.org/0000-0002-8818-7193'

```
Build the docs again
`make html && open _build/html/index.html`

The docs should now contain the new author:

![Screenshot 2024-05-21 at 12 15 31](https://github.com/PMBio/deeprvat/assets/135472/192acf84-784c-4afa-bc90-29fabf0e9434)


**_Note_**:
This will add new authors to the docs that were not present in the docs (but exist in the citations.cff).

Before:
`© Copyright 2024, Clarke, B., Holtkamp, E., Öztürk, H., Mück, M., Wahlberg, M., Meyer, K., Brechtmann, F., Hölzlwimmer, F. R., Gagneur, J., & Stegle, O`

After:

`© Copyright 2024, Clarke, B., Holtkamp, E., Öztürk, H., Mück, M., Wahlberg, M., Meyer, K., Munzlinger, F., Brechtmann, F., Hölzlwimmer, F., Gagneur, J., Stegle, O..`
