### PR TITLE
Add support pipeline test extra flags

### DIFF
--- a/.github/workflows/pipeline-tests.yml
+++ b/.github/workflows/pipeline-tests.yml
@@ -9,7 +9,6 @@ jobs:
     with:
       pipeline_file: ./pipelines/run_training.snakefile
       environment_file: ./deeprvat_env_no_gpu.yml
-      pipeline_extra_flags: --verbose
 
   Pipeline-Tests-RunTraining:
     needs: Smoke-RunTraining

--- a/.github/workflows/pipeline-tests.yml
+++ b/.github/workflows/pipeline-tests.yml
@@ -9,6 +9,7 @@ jobs:
     with:
       pipeline_file: ./pipelines/run_training.snakefile
       environment_file: ./deeprvat_env_no_gpu.yml
+      pipeline_extra_flags: --verbose
 
   Pipeline-Tests-RunTraining:
     needs: Smoke-RunTraining

--- a/.github/workflows/run-pipeline.yml
+++ b/.github/workflows/run-pipeline.yml
@@ -12,6 +12,9 @@ on:
       pipeline_file:
         required: true
         type: string
+      pipeline_extra_flags:
+        required: false
+        type: string
       no_gpu:
         required: false
         type: boolean
@@ -79,7 +82,7 @@ jobs:
             python -m snakemake ${{ (inputs.dry_run && '-n') || '' }} \
             -j 2 --directory ${{inputs.pipeline_directory}} \
             ${{ (endsWith(inputs.pipeline_config, 'ml') && '--configfile')  || '' }}  ${{ inputs.pipeline_config }} \
-            --snakefile ${{inputs.pipeline_file}} --show-failed-logs -F
+            --snakefile ${{inputs.pipeline_file}} --show-failed-logs -F ${{ inputs.pipeline_extra_flags }}
           shell: micromamba-shell {0}
         - name: Run post pipeline cmd
           if: inputs.postrun_cmd


### PR DESCRIPTION
# What

Updates the test-pipeline to add support for extra snakemake flags.

You can now pass extra flags to the snakemake cmd using the `pipeline_extra_flags` parameter.

```yml
jobs:
  # Training Pipeline
  Smoke-RunTraining:
    uses: ./.github/workflows/run-pipeline.yml
    with:
      pipeline_file: ./pipelines/run_training.snakefile
      environment_file: ./deeprvat_env_no_gpu.yml
      pipeline_extra_flags: --verbose # Example of adding the verbose flag

```

