### PR TITLE
Show the commands that run in pipeline tests

### DIFF
--- a/.github/workflows/run-pipeline.yml
+++ b/.github/workflows/run-pipeline.yml
@@ -82,7 +82,7 @@ jobs:
             python -m snakemake ${{ (inputs.dry_run && '-n') || '' }} \
             -j 2 --directory ${{inputs.pipeline_directory}} \
             ${{ (endsWith(inputs.pipeline_config, 'ml') && '--configfile')  || '' }}  ${{ inputs.pipeline_config }} \
-            --snakefile ${{inputs.pipeline_file}} --show-failed-logs -F ${{ inputs.pipeline_extra_flags }}
+            --snakefile ${{inputs.pipeline_file}} --show-failed-logs -F -p ${{ inputs.pipeline_extra_flags }}
           shell: micromamba-shell {0}
         - name: Run post pipeline cmd
           if: inputs.postrun_cmd


### PR DESCRIPTION
# What

This PR updates the pipelines to output the commands that run to make it easier to debug the pipelines running in github actions.

# Testing
Check the pipeline runs and make sure you can see the cmd outputs.

![Skärmavbild 2024-05-29 kl  13 57 05](https://github.com/PMBio/deeprvat/assets/135472/f1838617-21af-4a62-b133-12916036e13f)
![Skärmavbild 2024-05-29 kl  13 57 24](https://github.com/PMBio/deeprvat/assets/135472/0b3c5720-1f0f-4e02-aee9-75b063d0f4f5)
