### PR TITLE
Regenerate IDs for VEP annotation inout VCFs

### DIFF
--- a/pipelines/annotations.snakefile
+++ b/pipelines/annotations.snakefile
@@ -299,7 +299,7 @@ rule strip_chr_name:
     output:
         anno_tmp_dir / "{file_stem}_stripped.vcf.gz",
     shell:
-        f"{load_hts} cut -c 4- {{input}} |bgzip > {{output}}"
+        load_hts + """ cut -c 4- {input} | awk -F'\\t' 'BEGIN {{OFS = FS}} {{$3 = "chr"$1"_"$2"_"$4"_"$5; print}}' |bgzip > {output} """
 
 
 rule vep:


### PR DESCRIPTION
# What
When VCF files are normalized, sometimes there are multiple IDs for each variant concatenated with a semicolon(;) THis however leads to problems with the `#Uploaded_variation` column in VEP. This PR regenerates the IDs and makes sure each variant gets a unique ID. 
Related to Issue #76, specifically this comment https://github.com/PMBio/deeprvat/issues/76#issuecomment-2139008285

# Testing
Tested locally on example data

## Test scenarios
Run pipeline locally
