### PR TITLE
Calibration Option for Burden Scores

### DIFF
--- a/deeprvat/deeprvat/associate.py
+++ b/deeprvat/deeprvat/associate.py
@@ -26,6 +26,7 @@ from torch.utils.data import DataLoader, Dataset, Subset
 from tqdm import tqdm, trange
 import zarr
 import re
+import dask.array as da
 
 import deeprvat.deeprvat.models as deeprvat_models
 from deeprvat.data import DenseGTDataset
@@ -846,6 +847,7 @@ def load_models(
 @click.option("--chunk", type=int)
 @click.option("--dataset-file", type=click.Path(exists=True))
 @click.option("--link-burdens", type=click.Path())
+@click.option("--center-scale-burdens", is_flag=True)
 @click.argument("data-config-file", type=click.Path(exists=True))
 @click.argument("model-config-file", type=click.Path(exists=True))
 @click.argument("checkpoint-files", type=click.Path(exists=True), nargs=-1)
@@ -857,6 +859,7 @@ def compute_burdens(
     chunk: Optional[int],
     dataset_file: Optional[str],
     link_burdens: Optional[str],
+    center_scale_burdens: bool,
     data_config_file: str,
     model_config_file: str,
     checkpoint_files: Tuple[str],
@@ -877,6 +880,8 @@ def compute_burdens(
     :type dataset_file: Optional[str]
     :param link_burdens: Path to burden.zarr file to link.
     :type link_burdens: Optional[str]
+    :param center_scale_burdens: Flag to enable calculation of center and scaling parameters for centering and scaling burden results.
+    :type center_scale_burdens: bool
     :param data_config_file: Path to the data configuration file.
     :type data_config_file: str
     :param model_config_file: Path to the model configuration file.
@@ -932,6 +937,25 @@ def compute_burdens(
         skip_burdens=(link_burdens is not None),
     )
 
+    if center_scale_burdens and not link_burdens:
+        if (chunk == 0) or not chunk:
+            empty_batch = {
+                "rare_variant_annotations": torch.zeros(1,1,34,1),
+                "y": None,
+                "x_phenotypes": None,
+                "sample": None,
+            }
+            this_mode, _, _, _ = get_burden(
+                    empty_batch, agg_models, device=device, skip_burdens=False, compute_mode=True
+                )
+            this_mode = this_mode.flatten()
+            center_scale_df = pd.DataFrame(columns=["max","mode"])
+            for r in range(len(agg_models)):
+                center_scale_df.loc[r,"max"] = None
+                center_scale_df.loc[r,"mode"] = this_mode[r]
+            pprint(f"Calculated Zero-Effect Burden Score :\n {this_mode}")
+            center_scale_df.to_csv(f"{Path(out_dir)}/computed_burdens_stats.csv", index=False)   
+
     logger.info("Saving computed burdens, corresponding genes, and targets")
     np.save(Path(out_dir) / "genes.npy", genes)
     if link_burdens is not None:
@@ -958,7 +982,6 @@ def regress_on_gene_scoretest(
     :rtype: Tuple[List[str], List[float], List[float]]
     """
     burdens = burdens.reshape(burdens.shape[0], -1)
-    assert np.all(burdens != 0)  # because DeepRVAT burdens are corrently all non-zero
     logger.info(f"Burdens shape: {burdens.shape}")
 
     if np.all(np.abs(burdens) < 1e-6):
@@ -1300,6 +1323,7 @@ def combine_regression_results(
 
 
 @cli.command()
+@click.option("--center-scale-burdens", is_flag=True)
 @click.option("--n-chunks", type=int)
 @click.option("--chunk", type=int)
 @click.option("-r", "--repeats", multiple=True, type=int)
@@ -1307,6 +1331,7 @@ def combine_regression_results(
 @click.argument("burden-file", type=click.Path(exists=True))
 @click.argument("burden-out-file", type=click.Path())
 def average_burdens(
+    center_scale_burdens: bool,
     repeats: Tuple,
     burden_file: str,
     burden_out_file: str,
@@ -1319,6 +1344,19 @@ def average_burdens(
     logger.info(f"Reading burdens to aggregate from {burden_file}")
     burdens = zarr.open(burden_file)
     n_total_samples = burdens.shape[0]
+    
+    if center_scale_burdens:
+        center_scale_params_file = Path(os.path.split(burden_out_file)[0]) / "computed_burdens_stats.csv"
+        center_scale_df = pd.read_csv(center_scale_params_file)
+        if (chunk == 0) or not chunk:
+            xd = da.from_zarr(burden_file,chunks=(1000,1000,1))
+            for r in range(len(repeats)):
+                repeat_max = xd[:,:,r].max().compute() # compute max across each repeat
+                center_scale_df.loc[r,"max"] = repeat_max
+                
+            pprint(f"Center and scaling values extracted from computed burdens :\n{center_scale_df}")
+            center_scale_df.to_csv(center_scale_params_file, index=False)   
+    
     if chunk is not None:
         if n_chunks is None:
             raise ValueError("n_chunks must be specified if chunk is not None")
@@ -1366,6 +1404,23 @@ def average_burdens(
         end_idx = min(start_idx + batch_size, chunk_end)
         print(start_idx, end_idx)
         this_burdens = np.take(burdens[start_idx:end_idx, :, :], repeats, axis=2)
+        
+        #Double-check zarr creation - no computed burdens should equal zero
+        assert np.all(this_burdens != 0)
+
+        if center_scale_burdens:
+            print("Centering and Scaling Burdens before aggregating")
+            for r in range(len(repeats)):
+                zero_effect_val = center_scale_df.loc[r,"mode"]
+                repeat_max = center_scale_df.loc[r,"max"]
+                # Subtract off zero effect burden value (mode)
+                this_burdens[:,:,r] -= zero_effect_val
+                adjusted_max = repeat_max - zero_effect_val
+                # Scale only values >= mode. Scale between 0 and 1.
+                pos_mask = this_burdens[:,:,r] > 0
+                # (this_burdens[:,:,r][pos_mask] - this_burdens[:,:,r][pos_mask].min()) / (adjusted_max - this_burdens[:,:,r][pos_mask].min())
+                this_burdens[:,:,r][pos_mask] /= adjusted_max
+
         this_burdens = AGG_FCT[agg_fct](this_burdens, axis=2)
 
         burdens_new[start_idx:end_idx, :, 0] = this_burdens

--- a/deeprvat/deeprvat/config.py
+++ b/deeprvat/deeprvat/config.py
@@ -309,6 +309,7 @@ def create_main_config(
         "correction_method"
     ]
     full_config["evaluation"]["alpha"] = input_config["evaluation"]["alpha"]
+    full_config["center_scale_burdens"] = input_config["evaluation"]["center_scale_burdens"]
     # DeepRVAT model
     full_config["n_repeats"] = input_config["n_repeats"]
 

--- a/example/config/deeprvat_input_config.yaml
+++ b/example/config/deeprvat_input_config.yaml
@@ -151,6 +151,7 @@ y_transformation: quantile_transform
 evaluation:
   correction_method: Bonferroni
   alpha: 0.05
+  center_scale_burdens: False
 
 # Subsetting samples for training or association testing
 #sample_files:

--- a/example/config/deeprvat_input_pretrained_models_config.yaml
+++ b/example/config/deeprvat_input_pretrained_models_config.yaml
@@ -72,6 +72,7 @@ y_transformation: quantile_transform
 evaluation:
   correction_method: Bonferroni
   alpha: 0.05
+  center_scale_burdens: False
 
 # Subsetting samples for association testing
 #sample_files:

--- a/pipelines/association_testing/burdens.snakefile
+++ b/pipelines/association_testing/burdens.snakefile
@@ -19,6 +19,7 @@ rule average_burdens:
     shell:
         ' && '.join([
             ('deeprvat_associate  average-burdens '
+            + center_scale_burdens +
             '--n-chunks '+ str(n_avg_chunks) + ' '
             '--chunk {wildcards.chunk} '
             '{params.repeats} '
@@ -83,6 +84,7 @@ rule compute_burdens:
         ' && '.join([
             ('deeprvat_associate compute-burdens '
              + debug +
+             + center_scale_burdens +
              ' --n-chunks '+ str(n_burden_chunks) + ' '
              '--chunk {wildcards.chunk} '
              '--dataset-file {input.dataset} '

--- a/pipelines/association_testing/burdens.snakefile
+++ b/pipelines/association_testing/burdens.snakefile
@@ -18,7 +18,7 @@ rule average_burdens:
     priority: 10,
     shell:
         ' && '.join([
-            ('deeprvat_associate  average-burdens '
+            ('deeprvat_associate average-burdens '
             + center_scale_burdens +
             '--n-chunks '+ str(n_avg_chunks) + ' '
             '--chunk {wildcards.chunk} '
@@ -84,10 +84,10 @@ rule compute_burdens:
         ' && '.join([
             ('deeprvat_associate compute-burdens '
              + debug +
-             + center_scale_burdens +
              ' --n-chunks '+ str(n_burden_chunks) + ' '
              '--chunk {wildcards.chunk} '
              '--dataset-file {input.dataset} '
+             + center_scale_burdens +
              '{input.data_config} '
              '{input.model_config} '
              '{input.checkpoints} '

--- a/pipelines/association_testing_pretrained.snakefile
+++ b/pipelines/association_testing_pretrained.snakefile
@@ -18,6 +18,7 @@ training_phenotypes = []
 n_burden_chunks = config.get('n_burden_chunks', 1) if not debug_flag else 2
 n_regression_chunks = config.get('n_regression_chunks', 40) if not debug_flag else 2
 n_avg_chunks = config.get('n_avg_chunks', 1)
+center_scale_burdens = '--center-scale-burdens ' if config.get('center_scale_burdens', False) else ''
 n_trials = config['hyperparameter_optimization']['n_trials']
 n_bags = config['training']['n_bags'] if not debug_flag else 3
 n_repeats = config['n_repeats']

--- a/pipelines/association_testing_pretrained_regenie.snakefile
+++ b/pipelines/association_testing_pretrained_regenie.snakefile
@@ -18,6 +18,7 @@ training_phenotypes = []
 n_burden_chunks = config.get('n_burden_chunks', 1) if not debug_flag else 2
 n_regression_chunks = config.get('n_regression_chunks', 40) if not debug_flag else 2
 n_avg_chunks = config.get('n_avg_chunks', 1)
+center_scale_burdens = '--center-scale-burdens ' if config.get('center_scale_burdens', False) else ''
 n_bags = config['training']['n_bags'] if not debug_flag else 3
 n_repeats = config['n_repeats']
 debug = '--debug ' if debug_flag else ''

--- a/pipelines/training_association_testing.snakefile
+++ b/pipelines/training_association_testing.snakefile
@@ -18,6 +18,7 @@ training_phenotypes = config["training"].get("phenotypes", phenotypes)
 n_burden_chunks = config.get('n_burden_chunks', 1) if not debug_flag else 2
 n_regression_chunks = config.get('n_regression_chunks', 40) if not debug_flag else 2
 n_avg_chunks = config.get('n_avg_chunks', 1)
+center_scale_burdens = '--center-scale-burdens ' if config.get('center_scale_burdens', False) else ''
 n_trials = config['hyperparameter_optimization']['n_trials']
 n_bags = config['training']['n_bags'] if not debug_flag else 3
 n_repeats = config['n_repeats']

--- a/pipelines/training_association_testing_regenie.snakefile
+++ b/pipelines/training_association_testing_regenie.snakefile
@@ -18,6 +18,7 @@ training_phenotypes = config["training"].get("phenotypes", phenotypes)
 n_burden_chunks = config.get('n_burden_chunks', 1) if not debug_flag else 2
 n_regression_chunks = config.get('n_regression_chunks', 40) if not debug_flag else 2
 n_avg_chunks = config.get('n_avg_chunks', 1)
+center_scale_burdens = '--center-scale-burdens ' if config.get('center_scale_burdens', False) else ''
 n_trials = config['hyperparameter_optimization']['n_trials']
 n_bags = config['training']['n_bags'] if not debug_flag else 3
 n_repeats = config['n_repeats']
@@ -26,7 +27,7 @@ do_scoretest = '--do-scoretest ' if config.get('do_scoretest', False) else ''
 tensor_compression_level = config['training'].get('tensor_compression_level', 1)
 model_path = Path("models")
 n_parallel_training_jobs = config["training"].get("n_parallel_jobs", 1)
-cv_exp = False
+cv_exp = config.get('cv_exp', False)
 
 wildcard_constraints:
     repeat="\d+",


### PR DESCRIPTION
# What
This PR adds the option to calibrate the burden scores prior to association testing. This includes _centering_ by subtracting the null-effect burden score, followed by a _scaling_ of the resulting positive burden scores between the values of 0 and 1.

# Testing
Testing this PR involves running the association testing part of the pipeline. A pre-trained DeepRVAT model setup can be used to test the burden calibration feature. Specify in the deeprvat_config.yaml file the `center_scale_burdens: True` to initiate the calibration.