### PR TITLE
Fix update_config key-error in pipeline

### DIFF
--- a/deeprvat/deeprvat/config.py
+++ b/deeprvat/deeprvat/config.py
@@ -227,10 +227,7 @@ def create_main_config(
             )
 
     # Phenotypes
-    full_config["phenotypes"] = {}
-    for pheno in input_config["phenotypes_for_association_testing"]:
-        full_config["phenotypes"][pheno] = {}
-        # Can optionally specify dictionary of = {"min_seed_genes": 3, "max_seed_genes": None, "pvalue_threshold": None}
+    full_config["phenotypes"] = input_config["phenotypes_for_association_testing"]
     # genotypes.h5
     full_config["training_data"]["gt_file"] = input_config["gt_filename"]
     full_config["association_testing_data"]["gt_file"] = input_config["gt_filename"]
@@ -333,7 +330,10 @@ def create_main_config(
             "early_stopping"
         ]
         # Training Phenotypes
-        full_config["training"]["phenotypes"] = input_config["phenotypes_for_training"]
+        full_config["training"]["phenotypes"] = {}
+        for pheno in input_config["phenotypes_for_training"]:
+            full_config["training"]["phenotypes"][pheno] = {}
+            # Can optionally specify dictionary of = {"min_seed_genes": 3, "max_seed_genes": None, "pvalue_threshold": None}
         # Baseline results
         if "baseline_results" not in full_config:
             full_config["baseline_results"] = {}
@@ -561,7 +561,7 @@ def update_config(
                     "--phenotype and --seed-genes-out must be "
                     "specified if --baseline-results is"
                 )
-            seed_config = config["phenotypes"][phenotype]
+            seed_config = config["training"]["phenotypes"][phenotype]
             correction_method = config["baseline_results"].get(
                 "correction_method", None
             )

--- a/pipelines/association_testing_control_for_common_variants.snakefile
+++ b/pipelines/association_testing_control_for_common_variants.snakefile
@@ -14,7 +14,7 @@ debug_flag = config.get('debug', False)
 phenotypes = config['phenotypes']
 phenotypes = list(phenotypes.keys()) if type(phenotypes) == dict else phenotypes
 training_phenotypes = config["training"].get("phenotypes", phenotypes)
-
+training_phenotypes = list(training_phenotypes.keys()) if type(training_phenotypes) == dict else training_phenotypes
 
 n_burden_chunks = config.get('n_burden_chunks', 1) if not debug_flag else 2
 

--- a/pipelines/cv_training/cv_training_association_testing.snakefile
+++ b/pipelines/cv_training/cv_training_association_testing.snakefile
@@ -17,6 +17,7 @@ debug_flag = config.get("debug", False)
 phenotypes = config["phenotypes"]
 phenotypes = list(phenotypes.keys()) if type(phenotypes) == dict else phenotypes
 training_phenotypes = config["training"].get("phenotypes", phenotypes)
+training_phenotypes = list(training_phenotypes.keys()) if type(training_phenotypes) == dict else training_phenotypes
 burden_phenotype = phenotypes[0]
 
 n_burden_chunks = config.get("n_burden_chunks", 1) if not debug_flag else 2

--- a/pipelines/run_training.snakefile
+++ b/pipelines/run_training.snakefile
@@ -14,6 +14,7 @@ debug_flag = config.get('debug', False)
 phenotypes = config['phenotypes']
 phenotypes = list(phenotypes.keys()) if type(phenotypes) == dict else phenotypes
 training_phenotypes = config["training"].get("phenotypes", phenotypes)
+training_phenotypes = list(training_phenotypes.keys()) if type(training_phenotypes) == dict else training_phenotypes
 
 n_burden_chunks = config.get('n_burden_chunks', 1) if not debug_flag else 2
 n_regression_chunks = config.get('n_regression_chunks', 40) if not debug_flag else 2

--- a/pipelines/training_association_testing.snakefile
+++ b/pipelines/training_association_testing.snakefile
@@ -14,6 +14,7 @@ debug_flag = config.get('debug', False)
 phenotypes = config['phenotypes']
 phenotypes = list(phenotypes.keys()) if type(phenotypes) == dict else phenotypes
 training_phenotypes = config["training"].get("phenotypes", phenotypes)
+training_phenotypes = list(training_phenotypes.keys()) if type(training_phenotypes) == dict else training_phenotypes
 
 n_burden_chunks = config.get('n_burden_chunks', 1) if not debug_flag else 2
 n_regression_chunks = config.get('n_regression_chunks', 40) if not debug_flag else 2

--- a/pipelines/training_association_testing_regenie.snakefile
+++ b/pipelines/training_association_testing_regenie.snakefile
@@ -14,6 +14,7 @@ debug_flag = config.get('debug', False)
 phenotypes = config['phenotypes']
 phenotypes = list(phenotypes.keys()) if type(phenotypes) == dict else phenotypes
 training_phenotypes = config["training"].get("phenotypes", phenotypes)
+training_phenotypes = list(training_phenotypes.keys()) if type(training_phenotypes) == dict else training_phenotypes
 
 n_burden_chunks = config.get('n_burden_chunks', 1) if not debug_flag else 2
 n_regression_chunks = config.get('n_regression_chunks', 40) if not debug_flag else 2

--- a/tests/deeprvat/pretrained/deeprvat_config.yaml
+++ b/tests/deeprvat/pretrained/deeprvat_config.yaml
@@ -160,11 +160,11 @@ n_burden_chunks: 5
 n_regression_chunks: 2
 n_repeats: 30
 phenotypes:
-  Cholesterol: {}
-  HDL_cholesterol: {}
-  Mean_platelet_thrombocyte_volume: {}
-  Platelet_count: {}
-  Platelet_distribution_width: {}
+  - Cholesterol
+  - HDL_cholesterol
+  - Mean_platelet_thrombocyte_volume
+  - Platelet_count
+  - Platelet_distribution_width
 pretrained_model_path: ../pretrained_models
 regenie_exp: false
 training:

--- a/tests/deeprvat/regenie/pretrained/deeprvat_config.yaml
+++ b/tests/deeprvat/regenie/pretrained/deeprvat_config.yaml
@@ -160,11 +160,11 @@ n_burden_chunks: 5
 n_regression_chunks: 2
 n_repeats: 30
 phenotypes:
-  Cholesterol: {}
-  HDL_cholesterol: {}
-  Mean_platelet_thrombocyte_volume: {}
-  Platelet_count: {}
-  Platelet_distribution_width: {}
+  - Cholesterol
+  - HDL_cholesterol
+  - Mean_platelet_thrombocyte_volume
+  - Platelet_count
+  - Platelet_distribution_width
 pretrained_model_path: ../pretrained_models
 regenie_exp: false
 training:

--- a/tests/deeprvat/regenie/training_association_testing/deeprvat_config.yaml
+++ b/tests/deeprvat/regenie/training_association_testing/deeprvat_config.yaml
@@ -172,8 +172,8 @@ n_burden_chunks: 5
 n_regression_chunks: 2
 n_repeats: 1
 phenotypes:
-  Cholesterol: {}
-  Platelet_count: {}
+  - Cholesterol
+  - Platelet_count
 regenie_exp: false
 training:
   dataloader_config:
@@ -192,8 +192,8 @@ training:
   n_bags: 1
   n_parallel_jobs: 6
   phenotypes:
-    - Cholesterol
-    - Platelet_count
+    Cholesterol: {}
+    Platelet_count: {}
   pl_trainer:
     check_val_every_n_epoch: 1
     gpus: 0

--- a/tests/deeprvat/test_data/training/deeprvat_config.yaml
+++ b/tests/deeprvat/test_data/training/deeprvat_config.yaml
@@ -172,11 +172,11 @@ n_burden_chunks: 5
 n_regression_chunks: 2
 n_repeats: 6
 phenotypes:
-  Cholesterol: {}
-  HDL_cholesterol: {}
-  Mean_platelet_thrombocyte_volume: {}
-  Platelet_count: {}
-  Platelet_distribution_width: {}
+  - Cholesterol
+  - HDL_cholesterol
+  - Mean_platelet_thrombocyte_volume
+  - Platelet_count
+  - Platelet_distribution_width
 regenie_exp: false
 training:
   dataloader_config:
@@ -195,27 +195,27 @@ training:
   n_bags: 1
   n_parallel_jobs: 6
   phenotypes:
-    - Apolipoprotein_A
-    - Apolipoprotein_B
-    - Calcium
-    - Cholesterol
-    - Red_blood_cell_erythrocyte_count
-    - HDL_cholesterol
-    - IGF_1
-    - LDL_direct
-    - Lymphocyte_percentage
-    - Mean_platelet_thrombocyte_volume
-    - Mean_corpuscular_volume
-    - Mean_reticulocyte_volume
-    - Neutrophill_count
-    - Platelet_count
-    - Platelet_crit
-    - Platelet_distribution_width
-    - SHBG
-    - Standing_height
-    - Total_bilirubin
-    - Triglycerides
-    - Urate
+    Apolipoprotein_A: {}
+    Apolipoprotein_B: {}
+    Calcium: {}
+    Cholesterol: {}
+    Red_blood_cell_erythrocyte_count: {}
+    HDL_cholesterol: {}
+    IGF_1: {}
+    LDL_direct: {}
+    Lymphocyte_percentage: {}
+    Mean_platelet_thrombocyte_volume: {}
+    Mean_corpuscular_volume: {}
+    Mean_reticulocyte_volume: {}
+    Neutrophill_count: {}
+    Platelet_count: {}
+    Platelet_crit: {}
+    Platelet_distribution_width: {}
+    SHBG: {}
+    Standing_height: {}
+    Total_bilirubin: {}
+    Triglycerides: {}
+    Urate: {}
   pl_trainer:
     check_val_every_n_epoch: 1
     gpus: 1

--- a/tests/deeprvat/training_association_testing/deeprvat_config.yaml
+++ b/tests/deeprvat/training_association_testing/deeprvat_config.yaml
@@ -172,8 +172,8 @@ n_burden_chunks: 5
 n_regression_chunks: 2
 n_repeats: 1
 phenotypes:
-  Cholesterol: {}
-  Platelet_count: {}
+  - Cholesterol
+  - Platelet_count
 regenie_exp: false
 training:
   dataloader_config:
@@ -192,8 +192,8 @@ training:
   n_bags: 1
   n_parallel_jobs: 6
   phenotypes:
-    - Cholesterol
-    - Platelet_count
+    Cholesterol: {}
+    Platelet_count: {}
   pl_trainer:
     check_val_every_n_epoch: 1
     gpus: 0


### PR DESCRIPTION
# What

Addresses Issue #114. Fixes a bug in update_config function to allow for specifying a set of phenotypes for training that do not also need to be listed under association testing phenotypes.

# Testing
Ran full training + association testing pipeline with config generation.