### PR TITLE
Update quickstart docs 

### DIFF
--- a/deeprvat/deeprvat/config.py
+++ b/deeprvat/deeprvat/config.py
@@ -11,6 +11,9 @@ from deeprvat.deeprvat.evaluate import pval_correction
 from pathlib import Path
 from copy import deepcopy
 
+REPO_DIR = (Path(__file__).parent / "../..").resolve()
+
+
 logging.basicConfig(
     format="[%(asctime)s] %(levelname)s:%(name)s: %(message)s",
     level="INFO",
@@ -54,15 +57,12 @@ def create_main_config(
         input_config = yaml.safe_load(f)
 
     # Base Config
-    with open(
-        f"{input_config['deeprvat_repo_dir']}/deeprvat/deeprvat/base_configurations.yaml"
-    ) as f:
+    with open(REPO_DIR / "deeprvat/deeprvat/base_configurations.yaml") as f:
         base_config = yaml.safe_load(f)
 
     full_config = base_config
 
     expected_input_keys = [
-        "deeprvat_repo_dir",
         "phenotypes_for_association_testing",
         "phenotypes_for_training",
         "gt_filename",
@@ -387,14 +387,13 @@ def create_sg_discovery_config(
 
     # Base Config
     with open(
-        f"{input_config['deeprvat_repo_dir']}/deeprvat/seed_gene_discovery/seed_gene_base_configurations.yaml"
+        REPO_DIR / "deeprvat/seed_gene_discovery/seed_gene_base_configurations.yaml"
     ) as f:
         base_config = yaml.safe_load(f)
 
     full_config = base_config
 
     expected_input_keys = [
-        "deeprvat_repo_dir",
         "phenotypes",
         "gt_filename",
         "variant_filename",

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -28,11 +28,13 @@ Note that the example data used here is randomly generated, and so is only suite
 ### Run the association testing pipeline with pretrained models
 
 ```shell
+DEEPRVAT_REPO_PATH="[path_to_deeprvat]"
 mkdir deeprvat_associate
 cd deeprvat_associate
-ln -s [path_to_deeprvat]/example/* .
-ln -s [path_to_deeprvat]/pretrained_models
-snakemake -j 1 --snakefile [path_to_deeprvat]/pipelines/association_testing_pretrained.snakefile
+ln -s "$DEEPRVAT_REPO_PATH"/example/* .
+ln -s "$DEEPRVAT_REPO_PATH"/pretrained_models
+ln -s config/deeprvat_input_pretrained_models_config.yaml . # Get the corresponding config.
+snakemake -j 1 --snakefile "$DEEPRVAT_REPO_PATH"/pipelines/association_testing_pretrained.snakefile
 ```
 
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -62,8 +62,10 @@ snakemake -j 1 --snakefile [path_to_deeprvat]/pipelines/run_training.snakefile
 ### Run the full training and association testing pipeline on some example data
 
 ```shell
+DEEPRVAT_REPO_PATH="[path_to_deeprvat]"
 mkdir deeprvat_train_associate
 cd deeprvat_train_associate
-ln -s [path_to_deeprvat]/example/* .
-snakemake -j 1 --snakefile [path_to_deeprvat]/pipelines/training_association_testing.snakefile
+ln -s "$DEEPRVAT_REPO_PATH"/example/* .
+ln -s config/deeprvat_input_config.yaml .
+snakemake -j 1 --snakefile "$DEEPRVAT_REPO_PATH"/pipelines/training_association_testing.snakefile
 ```

--- a/example/config/deeprvat_input_config.yaml
+++ b/example/config/deeprvat_input_config.yaml
@@ -1,4 +1,3 @@
-deeprvat_repo_dir: ../..
 
 # Phenotypes to be used only for Association Testing
 phenotypes_for_association_testing:

--- a/example/config/deeprvat_input_pretrained_models_config.yaml
+++ b/example/config/deeprvat_input_pretrained_models_config.yaml
@@ -1,7 +1,5 @@
-deeprvat_repo_dir: ../..
-
 use_pretrained_models: True
-pretrained_model_path : ../../pretrained_models
+pretrained_model_path : pretrained_models
 
 #Phenotypes to be used only for Association Testing
 phenotypes_for_association_testing:

--- a/example/config/seed_gene_discovery_input_config.yaml
+++ b/example/config/seed_gene_discovery_input_config.yaml
@@ -1,4 +1,3 @@
-deeprvat_repo_dir: ../..
 
 # Phenotypes to calculate the seed gene baseline results for
 phenotypes:


### PR DESCRIPTION
# What

Updates the docs to reflect changes in config setup for `association testing pipeline with pretrained models` and `full training and association testing pipeline
`
related issue https://github.com/PMBio/deeprvat/issues/124

# Testing
Test the examples in the docs:


### Run the full training and association testing pipeline on some example data

```shell
DEEPRVAT_REPO_PATH="[path_to_deeprvat]"
mkdir deeprvat_train_associate
cd deeprvat_train_associate
ln -s "$DEEPRVAT_REPO_PATH"/example/* .
ln -s config/deeprvat_input_config.yaml .
snakemake -j 1 --snakefile "$DEEPRVAT_REPO_PATH"/pipelines/training_association_testing.snakefile
```
### Run the association testing pipeline with pretrained models

```shell
DEEPRVAT_REPO_PATH="[path_to_deeprvat]"
mkdir deeprvat_associate
cd deeprvat_associate
ln -s "$DEEPRVAT_REPO_PATH"/example/* .
ln -s "$DEEPRVAT_REPO_PATH"/pretrained_models
ln -s config/deeprvat_input_pretrained_models_config.yaml . # Get the corresponding config.
snakemake -j 1 --snakefile "$DEEPRVAT_REPO_PATH"/pipelines/association_testing_pretrained.snakefile
```
