### PR TITLE
Create PyTests for config file setups

### DIFF
--- a/.github/workflows/pipeline-tests.yml
+++ b/.github/workflows/pipeline-tests.yml
@@ -23,7 +23,7 @@ jobs:
     with:
       pipeline_file: ./pipelines/association_testing_pretrained.snakefile
       environment_file: ./deeprvat_env_no_gpu.yml
-      prerun_cmd: cp ./example/config/deeprvat_input_pretrained_models_config.yaml ./example/ && ln -s ./pretrained_models ./example/
+      prerun_cmd: cp ./example/config/deeprvat_input_pretrained_models_config.yaml ./example/ && ln -s ${{ github.workspace }}/pretrained_models ./example/
 
 
   # Training Pipeline

--- a/.github/workflows/pipeline-tests.yml
+++ b/.github/workflows/pipeline-tests.yml
@@ -23,7 +23,7 @@ jobs:
     with:
       pipeline_file: ./pipelines/association_testing_pretrained.snakefile
       environment_file: ./deeprvat_env_no_gpu.yml
-      prerun_cmd: cp ./example/config/deeprvat_input_pretrained_models_config.yaml ./example/ && ln -s ${{ github.workspace }}/pretrained_models ./example/
+      prerun_cmd: cp ./example/config/deeprvat_input_pretrained_models_config.yaml ./example/ && ln -s $GITHUB_WORKSPACE/pretrained_models ./example/
 
 
   # Training Pipeline

--- a/.github/workflows/pipeline-tests.yml
+++ b/.github/workflows/pipeline-tests.yml
@@ -9,7 +9,7 @@ jobs:
     with:
       pipeline_file: ./pipelines/run_training.snakefile
       environment_file: ./deeprvat_env_no_gpu.yml
-      prerun_cmd: cp ./example/config/deeprvat_input_training_config.yaml ./example/
+      prerun_cmd: cp ./example/config/deeprvat_input_training_config.yaml ./example/ 
   
   Smoke-GenerateConfig-Training-AssociationTesting:
     uses: ./.github/workflows/run-pipeline.yml
@@ -23,7 +23,7 @@ jobs:
     with:
       pipeline_file: ./pipelines/association_testing_pretrained.snakefile
       environment_file: ./deeprvat_env_no_gpu.yml
-      prerun_cmd: cp ./example/config/deeprvat_input_pretrained_models_config.yaml ./example/
+      prerun_cmd: cp ./example/config/deeprvat_input_pretrained_models_config.yaml ./example/ && ln -s ./pretrained_models ./example/
 
 
   # Training Pipeline

--- a/.github/workflows/pipeline-tests.yml
+++ b/.github/workflows/pipeline-tests.yml
@@ -3,6 +3,29 @@ run-name: DeepRVAT Pipeline Tests 🧬🧪💻🧑‍🔬
 on: [ push ]
 
 jobs:
+  # Config Setup
+  Smoke-GenerateConfig-Training:
+    uses: ./.github/workflows/run-pipeline.yml
+    with:
+      pipeline_file: ./pipelines/run_training.snakefile
+      environment_file: ./deeprvat_env_no_gpu.yml
+      prerun_cmd: cp ./example/config/deeprvat_input_training_config.yaml ./example/
+  
+  Smoke-GenerateConfig-Training-AssociationTesting:
+    uses: ./.github/workflows/run-pipeline.yml
+    with:
+      pipeline_file: ./pipelines/training_association_testing.snakefile
+      environment_file: ./deeprvat_env_no_gpu.yml
+      prerun_cmd: cp ./example/config/deeprvat_input_config.yaml ./example/
+
+  Smoke-GenerateConfig-PreTrained:
+    uses: ./.github/workflows/run-pipeline.yml
+    with:
+      pipeline_file: ./pipelines/association_testing_pretrained.snakefile
+      environment_file: ./deeprvat_env_no_gpu.yml
+      prerun_cmd: cp ./example/config/deeprvat_input_pretrained_models_config.yaml ./example/
+
+
   # Training Pipeline
   Smoke-RunTraining:
     uses: ./.github/workflows/run-pipeline.yml

--- a/deeprvat/deeprvat/config.py
+++ b/deeprvat/deeprvat/config.py
@@ -83,11 +83,18 @@ def create_main_config(
         "regenie_options",
     ]
 
+    # Check if Training Only
+    if input_config.get("training_only", False): 
+        train_only = True
+        to_remove = {"phenotypes_for_association_testing", "association_testing_data_thresholds","evaluation"}
+        expected_input_keys = [
+            item for item in expected_input_keys if item not in to_remove
+        ]
+        input_config.pop("training_only", None)
+    else: train_only = False
+
     # CV setup parameters
-    if not input_config["cv_options"]["cv_exp"]:
-        logger.info("Not CV setup...removing CV pipeline parameters from config")
-        full_config["cv_exp"] = False
-    else:  # CV experiment setup specified
+    if input_config.get("cv_options", {}).get("cv_exp", False):
         if any(
             key not in input_config["cv_options"]
             for key in ["cv_exp", "cv_path", "n_folds"]
@@ -99,14 +106,14 @@ def create_main_config(
         full_config["cv_path"] = input_config["cv_options"]["cv_path"]
         full_config["n_folds"] = input_config["cv_options"]["n_folds"]
         full_config["cv_exp"] = True
-
+    else:  
+        logger.info("Not CV setup...removing CV pipeline parameters from config")
+        full_config["cv_exp"] = False
+        expected_input_keys.remove("cv_options")
+        input_config.pop("cv_options", None)
+    
     # REGENIE setup parameters
-    if not input_config["regenie_options"]["regenie_exp"]:
-        logger.info(
-            "Not using REGENIE integration...removing REGENIE parameters from config"
-        )
-        full_config["regenie_exp"] = False
-    else:  # REGENIE integration
+    if input_config.get("regenie_options",{}).get("regenie_exp", False):
         if any(
             key not in input_config["regenie_options"]
             for key in ["regenie_exp", "step_1", "step_2"]
@@ -124,58 +131,71 @@ def create_main_config(
         full_config["regenie_options"]["step_2"] = input_config["regenie_options"][
             "step_2"
         ]
+    else:
+        logger.info(
+            "Not using REGENIE integration...removing REGENIE parameters from config"
+        )
+        full_config["regenie_exp"] = False
+        expected_input_keys.remove("regenie_options")
+        input_config.pop("regenie_options", None)
+
 
     no_pretrain = True
-    if "use_pretrained_models" in input_config:
-        if input_config["use_pretrained_models"]:
-            no_pretrain = False
-            logger.info("Pretrained Model setup specified.")
-            to_remove = {"training", "phenotypes_for_training", "seed_gene_results"}
-            expected_input_keys = [
-                item for item in expected_input_keys if item not in to_remove
-            ]
+    if input_config.get("use_pretrained_models", False):
+        no_pretrain = False
+        logger.info("Pretrained Model setup specified.")
+        to_remove = {"training", "phenotypes_for_training", "seed_gene_results"}
+        expected_input_keys = [
+            item for item in expected_input_keys if item not in to_remove
+        ]
 
-            pretrained_model_path = Path(input_config["pretrained_model_path"])
+        pretrained_model_path = Path(input_config["pretrained_model_path"])
 
-            expected_input_keys.extend(
-                ["use_pretrained_models", "model", "pretrained_model_path"]
-            )
+        expected_input_keys.extend(
+            ["use_pretrained_models", "model", "pretrained_model_path"]
+        )
 
-            with open(f"{pretrained_model_path}/model_config.yaml") as f:
-                pretrained_config = yaml.safe_load(f)
+        with open(f"{pretrained_model_path}/model_config.yaml") as f:
+            pretrained_config = yaml.safe_load(f)
 
-            required_keys = [
-                "model",
-                "rare_variant_annotations",
-                "training_data_thresholds",
-            ]
-            for k in pretrained_config:
-                if k not in required_keys:
-                    raise KeyError(
-                        (
-                            f"Unexpected key in pretrained_model_path/model_config.yaml file : {k} "
-                            "Please review DEEPRVAT_DIR/pretrained_models/model_config.yaml for expected list of keys."
-                        )
+        required_keys = [
+            "model",
+            "rare_variant_annotations",
+            "training_data_thresholds",
+        ]
+        for k in pretrained_config:
+            if k not in required_keys:
+                raise KeyError(
+                    (
+                        f"Unexpected key in pretrained_model_path/model_config.yaml file : {k} "
+                        "Please review DEEPRVAT_DIR/pretrained_models/model_config.yaml for expected list of keys."
                     )
-                else:
-                    input_config[k] = deepcopy(pretrained_config[k])
+                )
+            else:
+                input_config[k] = deepcopy(pretrained_config[k])
 
     if no_pretrain and "phenotypes_for_training" not in input_config:
         logger.info("Unspecified phenotype list for training.")
-        logger.info(
-            "   Setting training phenotypes to be the same set as specified by phenotypes_for_association_testing."
-        )
-        input_config["phenotypes_for_training"] = input_config[
-            "phenotypes_for_association_testing"
-        ]
+        if train_only:
+            raise KeyError((
+                "Must specify phenotypes_for_training in config file!"
+            ))
+        else:
+            logger.info(
+                "   Setting training phenotypes to be the same set as specified by phenotypes_for_association_testing."
+            )
+            input_config["phenotypes_for_training"] = input_config[
+                "phenotypes_for_association_testing"
+            ]
 
     if "y_transformation" in input_config:
         full_config["training_data"]["dataset_config"]["y_transformation"] = (
             input_config["y_transformation"]
         )
-        full_config["association_testing_data"]["dataset_config"][
-            "y_transformation"
-        ] = input_config["y_transformation"]
+        if not train_only:
+            full_config["association_testing_data"]["dataset_config"][
+                "y_transformation"
+            ] = input_config["y_transformation"]
     else:
         expected_input_keys.remove("y_transformation")
 
@@ -186,7 +206,7 @@ def create_main_config(
                 "Please review DEEPRVAT_DIR/example/config/deeprvat_input_config.yaml for list of keys."
             )
         )
-    if "MAF" not in input_config["association_testing_data_thresholds"]:
+    if not train_only and "MAF" not in input_config["association_testing_data_thresholds"]:
         raise KeyError(
             (
                 "Missing required MAF threshold in config['association_testing_data_thresholds']. "
@@ -223,51 +243,46 @@ def create_main_config(
                 "Please review DEEPRVAT_DIR/example/config/deeprvat_input_config.yaml for list of keys."
             )
 
-    # Phenotypes
-    full_config["phenotypes"] = input_config["phenotypes_for_association_testing"]
-    # genotypes.h5
-    full_config["training_data"]["gt_file"] = input_config["gt_filename"]
-    full_config["association_testing_data"]["gt_file"] = input_config["gt_filename"]
-    # variants.parquet
-    full_config["training_data"]["variant_file"] = input_config["variant_filename"]
-    full_config["association_testing_data"]["variant_file"] = input_config[
-        "variant_filename"
-    ]
-    # phenotypes.parquet
+    
+    full_config["training_data"]["gt_file"] = input_config["gt_filename"] # genotypes.h5
+    full_config["training_data"]["variant_file"] = input_config["variant_filename"] # variants.parquet
     full_config["training_data"]["dataset_config"]["phenotype_file"] = input_config[
         "phenotype_filename"
-    ]
-    full_config["association_testing_data"]["dataset_config"]["phenotype_file"] = (
-        input_config["phenotype_filename"]
-    )
-    # annotations.parquet
+    ] # phenotypes.parquet
     full_config["training_data"]["dataset_config"]["annotation_file"] = input_config[
         "annotation_filename"
-    ]
-    full_config["association_testing_data"]["dataset_config"]["annotation_file"] = (
-        input_config["annotation_filename"]
-    )
-    # protein_coding_genes.parquet
-    full_config["association_testing_data"]["dataset_config"]["gene_file"] = (
-        input_config["gene_filename"]
-    )
-    full_config["association_testing_data"]["dataset_config"]["rare_embedding"][
-        "config"
-    ]["gene_file"] = input_config["gene_filename"]
-    # rare_variant_annotations
+    ]  # annotations.parquet
     full_config["training_data"]["dataset_config"]["rare_embedding"]["config"][
         "annotations"
-    ] = input_config["rare_variant_annotations"]
-    full_config["association_testing_data"]["dataset_config"]["rare_embedding"][
-        "config"
-    ]["annotations"] = input_config["rare_variant_annotations"]
-    # covariates
+    ] = input_config["rare_variant_annotations"] # rare_variant_annotations
     full_config["training_data"]["dataset_config"]["x_phenotypes"] = input_config[
         "covariates"
-    ]
-    full_config["association_testing_data"]["dataset_config"]["x_phenotypes"] = (
-        input_config["covariates"]
-    )
+    ] # covariates
+    if not train_only:
+        full_config["phenotypes"] = input_config["phenotypes_for_association_testing"] # Phenotypes
+        full_config["association_testing_data"]["gt_file"] = input_config["gt_filename"] # genotypes.h5
+        full_config["association_testing_data"]["variant_file"] = input_config[
+            "variant_filename"
+        ] # variants.parquet
+        full_config["association_testing_data"]["dataset_config"]["phenotype_file"] = (
+            input_config["phenotype_filename"]
+        ) # phenotypes.parquet
+        full_config["association_testing_data"]["dataset_config"]["annotation_file"] = (
+            input_config["annotation_filename"]
+        ) #annotations.parquet
+        full_config["association_testing_data"]["dataset_config"]["rare_embedding"][
+            "config"
+        ]["gene_file"] = input_config["gene_filename"] # protein_coding_genes.parquet
+        full_config["association_testing_data"]["dataset_config"]["gene_file"] = (
+            input_config["gene_filename"]
+        ) # protein_coding_genes.parquet
+        full_config["association_testing_data"]["dataset_config"]["rare_embedding"][
+            "config"
+        ]["annotations"] = input_config["rare_variant_annotations"]  # rare_variant_annotations
+        full_config["association_testing_data"]["dataset_config"]["x_phenotypes"] = (
+            input_config["covariates"] # covariates
+        )
+    
     # Thresholds & variant annotations
     anno_list = deepcopy(input_config["rare_variant_annotations"])
     full_config["training_data"]["dataset_config"]["rare_embedding"]["config"][
@@ -280,29 +295,29 @@ def create_main_config(
         ][k] = f"{k} {v}"
         training_anno_list.insert(i + 1, k)
     full_config["training_data"]["dataset_config"]["annotations"] = training_anno_list
-
-    full_config["association_testing_data"]["dataset_config"]["rare_embedding"][
-        "config"
-    ]["thresholds"] = {}
-    association_anno_list = deepcopy(anno_list)
-    for i, (k, v) in enumerate(
-        input_config["association_testing_data_thresholds"].items()
-    ):
+    if not train_only:
         full_config["association_testing_data"]["dataset_config"]["rare_embedding"][
             "config"
-        ]["thresholds"][k] = f"{k} {v}"
-        association_anno_list.insert(i + 1, k)
-    full_config["association_testing_data"]["dataset_config"][
-        "annotations"
-    ] = association_anno_list
-
-    # Results evaluation parameters; alpha parameter for significance threshold
-    if "evaluation" not in full_config:
-        full_config["evaluation"] = {}
-    full_config["evaluation"]["correction_method"] = input_config["evaluation"][
-        "correction_method"
-    ]
-    full_config["evaluation"]["alpha"] = input_config["evaluation"]["alpha"]
+        ]["thresholds"] = {}
+        association_anno_list = deepcopy(anno_list)
+        for i, (k, v) in enumerate(
+            input_config["association_testing_data_thresholds"].items()
+        ):
+            full_config["association_testing_data"]["dataset_config"]["rare_embedding"][
+                "config"
+            ]["thresholds"][k] = f"{k} {v}"
+            association_anno_list.insert(i + 1, k)
+        full_config["association_testing_data"]["dataset_config"][
+            "annotations"
+        ] = association_anno_list
+        # Results evaluation parameters; alpha parameter for significance threshold
+        if "evaluation" not in full_config:
+            full_config["evaluation"] = {}
+        full_config["evaluation"]["correction_method"] = input_config["evaluation"][
+            "correction_method"
+        ]
+        full_config["evaluation"]["alpha"] = input_config["evaluation"]["alpha"]
+   
     # DeepRVAT model
     full_config["n_repeats"] = input_config["n_repeats"]
 

--- a/deeprvat/deeprvat/config.py
+++ b/deeprvat/deeprvat/config.py
@@ -84,14 +84,19 @@ def create_main_config(
     ]
 
     # Check if Training Only
-    if input_config.get("training_only", False): 
+    if input_config.get("training_only", False):
         train_only = True
-        to_remove = {"phenotypes_for_association_testing", "association_testing_data_thresholds","evaluation"}
+        to_remove = {
+            "phenotypes_for_association_testing",
+            "association_testing_data_thresholds",
+            "evaluation",
+        }
         expected_input_keys = [
             item for item in expected_input_keys if item not in to_remove
         ]
         input_config.pop("training_only", None)
-    else: train_only = False
+    else:
+        train_only = False
 
     # CV setup parameters
     if input_config.get("cv_options", {}).get("cv_exp", False):
@@ -106,14 +111,14 @@ def create_main_config(
         full_config["cv_path"] = input_config["cv_options"]["cv_path"]
         full_config["n_folds"] = input_config["cv_options"]["n_folds"]
         full_config["cv_exp"] = True
-    else:  
+    else:
         logger.info("Not CV setup...removing CV pipeline parameters from config")
         full_config["cv_exp"] = False
         expected_input_keys.remove("cv_options")
         input_config.pop("cv_options", None)
-    
+
     # REGENIE setup parameters
-    if input_config.get("regenie_options",{}).get("regenie_exp", False):
+    if input_config.get("regenie_options", {}).get("regenie_exp", False):
         if any(
             key not in input_config["regenie_options"]
             for key in ["regenie_exp", "step_1", "step_2"]
@@ -138,7 +143,6 @@ def create_main_config(
         full_config["regenie_exp"] = False
         expected_input_keys.remove("regenie_options")
         input_config.pop("regenie_options", None)
-
 
     no_pretrain = True
     if input_config.get("use_pretrained_models", False):
@@ -177,9 +181,7 @@ def create_main_config(
     if no_pretrain and "phenotypes_for_training" not in input_config:
         logger.info("Unspecified phenotype list for training.")
         if train_only:
-            raise KeyError((
-                "Must specify phenotypes_for_training in config file!"
-            ))
+            raise KeyError(("Must specify phenotypes_for_training in config file!"))
         else:
             logger.info(
                 "   Setting training phenotypes to be the same set as specified by phenotypes_for_association_testing."
@@ -206,7 +208,10 @@ def create_main_config(
                 "Please review DEEPRVAT_DIR/example/config/deeprvat_input_config.yaml for list of keys."
             )
         )
-    if not train_only and "MAF" not in input_config["association_testing_data_thresholds"]:
+    if (
+        not train_only
+        and "MAF" not in input_config["association_testing_data_thresholds"]
+    ):
         raise KeyError(
             (
                 "Missing required MAF threshold in config['association_testing_data_thresholds']. "
@@ -243,46 +248,59 @@ def create_main_config(
                 "Please review DEEPRVAT_DIR/example/config/deeprvat_input_config.yaml for list of keys."
             )
 
-    
-    full_config["training_data"]["gt_file"] = input_config["gt_filename"] # genotypes.h5
-    full_config["training_data"]["variant_file"] = input_config["variant_filename"] # variants.parquet
+    full_config["training_data"]["gt_file"] = input_config[
+        "gt_filename"
+    ]  # genotypes.h5
+    full_config["training_data"]["variant_file"] = input_config[
+        "variant_filename"
+    ]  # variants.parquet
     full_config["training_data"]["dataset_config"]["phenotype_file"] = input_config[
         "phenotype_filename"
-    ] # phenotypes.parquet
+    ]  # phenotypes.parquet
     full_config["training_data"]["dataset_config"]["annotation_file"] = input_config[
         "annotation_filename"
     ]  # annotations.parquet
     full_config["training_data"]["dataset_config"]["rare_embedding"]["config"][
         "annotations"
-    ] = input_config["rare_variant_annotations"] # rare_variant_annotations
+    ] = input_config[
+        "rare_variant_annotations"
+    ]  # rare_variant_annotations
     full_config["training_data"]["dataset_config"]["x_phenotypes"] = input_config[
         "covariates"
-    ] # covariates
+    ]  # covariates
     if not train_only:
-        full_config["phenotypes"] = input_config["phenotypes_for_association_testing"] # Phenotypes
-        full_config["association_testing_data"]["gt_file"] = input_config["gt_filename"] # genotypes.h5
+        full_config["phenotypes"] = input_config[
+            "phenotypes_for_association_testing"
+        ]  # Phenotypes
+        full_config["association_testing_data"]["gt_file"] = input_config[
+            "gt_filename"
+        ]  # genotypes.h5
         full_config["association_testing_data"]["variant_file"] = input_config[
             "variant_filename"
-        ] # variants.parquet
+        ]  # variants.parquet
         full_config["association_testing_data"]["dataset_config"]["phenotype_file"] = (
             input_config["phenotype_filename"]
-        ) # phenotypes.parquet
+        )  # phenotypes.parquet
         full_config["association_testing_data"]["dataset_config"]["annotation_file"] = (
             input_config["annotation_filename"]
-        ) #annotations.parquet
+        )  # annotations.parquet
         full_config["association_testing_data"]["dataset_config"]["rare_embedding"][
             "config"
-        ]["gene_file"] = input_config["gene_filename"] # protein_coding_genes.parquet
+        ]["gene_file"] = input_config[
+            "gene_filename"
+        ]  # protein_coding_genes.parquet
         full_config["association_testing_data"]["dataset_config"]["gene_file"] = (
             input_config["gene_filename"]
-        ) # protein_coding_genes.parquet
+        )  # protein_coding_genes.parquet
         full_config["association_testing_data"]["dataset_config"]["rare_embedding"][
             "config"
-        ]["annotations"] = input_config["rare_variant_annotations"]  # rare_variant_annotations
+        ]["annotations"] = input_config[
+            "rare_variant_annotations"
+        ]  # rare_variant_annotations
         full_config["association_testing_data"]["dataset_config"]["x_phenotypes"] = (
-            input_config["covariates"] # covariates
+            input_config["covariates"]  # covariates
         )
-    
+
     # Thresholds & variant annotations
     anno_list = deepcopy(input_config["rare_variant_annotations"])
     full_config["training_data"]["dataset_config"]["rare_embedding"]["config"][
@@ -317,7 +335,7 @@ def create_main_config(
             "correction_method"
         ]
         full_config["evaluation"]["alpha"] = input_config["evaluation"]["alpha"]
-   
+
     # DeepRVAT model
     full_config["n_repeats"] = input_config["n_repeats"]
 

--- a/deeprvat/deeprvat/config.py
+++ b/deeprvat/deeprvat/config.py
@@ -618,9 +618,10 @@ def update_config(
             else:
                 logger.info("Not performing EAC filtering of baseline results")
             logger.info(f"  Correcting p-values using {correction_method} method")
-            alpha = config["baseline_results"].get(
-                "alpha_seed_genes", config["evaluation"].get("alpha")
-            )
+            if config["baseline_results"].get("alpha_seed_genes", False):
+                alpha = config["baseline_results"]["alpha_seed_genes"]
+            else:
+                alpha = config["evaluation"].get("alpha")
             baseline_df = pval_correction(
                 baseline_df, alpha, correction_type=correction_method
             )

--- a/deeprvat/deeprvat/config.py
+++ b/deeprvat/deeprvat/config.py
@@ -260,6 +260,9 @@ def create_main_config(
     full_config["training_data"]["dataset_config"]["annotation_file"] = input_config[
         "annotation_filename"
     ]  # annotations.parquet
+    full_config["association_testing_data"]["dataset_config"]["gene_file"] = (
+            input_config["gene_filename"]
+        )  # protein_coding_genes.parquet
     full_config["training_data"]["dataset_config"]["rare_embedding"]["config"][
         "annotations"
     ] = input_config[
@@ -289,9 +292,6 @@ def create_main_config(
         ]["gene_file"] = input_config[
             "gene_filename"
         ]  # protein_coding_genes.parquet
-        full_config["association_testing_data"]["dataset_config"]["gene_file"] = (
-            input_config["gene_filename"]
-        )  # protein_coding_genes.parquet
         full_config["association_testing_data"]["dataset_config"]["rare_embedding"][
             "config"
         ]["annotations"] = input_config[

--- a/deeprvat/deeprvat/config.py
+++ b/deeprvat/deeprvat/config.py
@@ -261,8 +261,8 @@ def create_main_config(
         "annotation_filename"
     ]  # annotations.parquet
     full_config["association_testing_data"]["dataset_config"]["gene_file"] = (
-            input_config["gene_filename"]
-        )  # protein_coding_genes.parquet
+        input_config["gene_filename"]
+    )  # protein_coding_genes.parquet
     full_config["training_data"]["dataset_config"]["rare_embedding"]["config"][
         "annotations"
     ] = input_config[

--- a/docs/input_data.md
+++ b/docs/input_data.md
@@ -8,17 +8,11 @@ Configuration for all pipelines is specified in the file `deeprvat_input_config.
 In the following, we describe the parameters (both optional and required) that can be specified in the `deeprvat_input_config.yaml` by way of an [example file](https://github.com/PMBio/deeprvat/blob/main/example/config/deeprvat_input_config.yaml), which we explain block by block.
 
 ```
-deeprvat_repo_dir: ../..
-```
-
-_Required._ This specifies the path to your copy of the DeepRVAT repository.
-
-```
 use_pretrained_models: True
-pretrained_model_path : ../../pretrained_models
+pretrained_model_path : pretrained_models
 ```
 
-These parameters are relevant when using pretrained models. `use_pretrained_models` defaults to `False` if not specified.
+These parameters are relevant when using pretrained models. `use_pretrained_models` defaults to `False` if not specified. Update the `pretrained_model_path` to the path where the `pretrained_models` directory is, if not in the same folder as your current experiment directory.
 
 ```
 phenotypes_for_association_testing:

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -52,10 +52,12 @@ snakemake -j 1 --snakefile [path_to_deeprvat]/pipelines/association_testing_pret
 ### Run the training pipeline on some example data
 
 ```shell
+DEEPRVAT_REPO_PATH="[path_to_deeprvat]"
 mkdir deeprvat_train
 cd deeprvat_train
-ln -s [path_to_deeprvat]/example/* .
-snakemake -j 1 --snakefile [path_to_deeprvat]/pipelines/run_training.snakefile
+ln -s "$DEEPRVAT_REPO_PATH"/example/* .
+ln -s config/deeprvat_input_training_config.yaml . #get the corresponding config.
+snakemake -j 1 --snakefile "$DEEPRVAT_REPO_PATH"/pipelines/run_training.snakefile
 ```
 
 

--- a/example/config/deeprvat_input_training_config.yaml
+++ b/example/config/deeprvat_input_training_config.yaml
@@ -1,0 +1,124 @@
+training_only: True
+
+# Phenotypes to be used only for training
+phenotypes_for_training:
+  - Apolipoprotein_A
+  - Apolipoprotein_B
+  - Calcium
+  - Cholesterol
+  - Red_blood_cell_erythrocyte_count
+
+# File paths of necessary input files to DeepRVAT
+gt_filename: genotypes.h5
+variant_filename: variants.parquet
+phenotype_filename: phenotypes.parquet
+annotation_filename: annotations.parquet
+gene_filename: protein_coding_genes.parquet
+
+rare_variant_annotations:
+  - MAF_MB
+  - CADD_raw
+  - sift_score
+  - polyphen_score
+  - Consequence_splice_acceptor_variant
+  - Consequence_splice_donor_variant
+  - Consequence_stop_gained
+  - Consequence_frameshift_variant
+  - Consequence_stop_lost
+  - Consequence_start_lost
+  - Consequence_inframe_insertion
+  - Consequence_inframe_deletion
+  - Consequence_missense_variant
+  - Consequence_protein_altering_variant
+  - Consequence_splice_region_variant
+  - condel_score
+  - DeepSEA_PC_1
+  - DeepSEA_PC_2
+  - DeepSEA_PC_3
+  - DeepSEA_PC_4
+  - DeepSEA_PC_5
+  - DeepSEA_PC_6
+  - PrimateAI_score
+  - AbSplice_DNA
+  - DeepRipe_plus_QKI_lip_hg2
+  - DeepRipe_plus_QKI_clip_k5
+  - DeepRipe_plus_KHDRBS1_clip_k5
+  - DeepRipe_plus_ELAVL1_parclip
+  - DeepRipe_plus_TARDBP_parclip
+  - DeepRipe_plus_HNRNPD_parclip
+  - DeepRipe_plus_MBNL1_parclip
+  - DeepRipe_plus_QKI_parclip
+  - SpliceAI_delta_score
+  - alphamissense
+
+covariates: #x_phenotypes
+  - age
+  - age2
+  - age_sex
+  - genetic_sex
+  - genetic_PC_1
+  - genetic_PC_2
+  - genetic_PC_3
+  - genetic_PC_4
+  - genetic_PC_5
+  - genetic_PC_6
+  - genetic_PC_7
+  - genetic_PC_8
+  - genetic_PC_9
+  - genetic_PC_10
+  - genetic_PC_11
+  - genetic_PC_12
+  - genetic_PC_13
+  - genetic_PC_14
+  - genetic_PC_15
+  - genetic_PC_16
+  - genetic_PC_17
+  - genetic_PC_18
+  - genetic_PC_19
+  - genetic_PC_20
+
+training_data_thresholds:
+  MAF: "< 1e-2"
+  CADD_PHRED: "> 5"
+
+# Seed Gene Baseline data settings
+seed_gene_results: #baseline_results
+  result_dirs:
+      -
+          base: baseline_results
+          type: plof/burden
+      -
+          base: baseline_results
+          type: missense/burden
+      -
+          base: baseline_results
+          type: plof/skat
+      -
+          base: baseline_results
+          type: missense/skat
+
+  correction_method: Bonferroni
+  alpha_seed_genes: 0.05
+
+# DeepRVAT training settings
+training:
+  pl_trainer: #PyTorch Lightening trainer settings
+      gpus: 1
+      precision: 16
+      min_epochs: 50
+      max_epochs: 1000
+      log_every_n_steps: 1
+      check_val_every_n_epoch: 1
+  early_stopping: #PyTorch Lightening Early Stopping Criteria
+      mode: min
+      patience: 3
+      min_delta: 0.00001
+      verbose: True
+
+# DeepRVAT model settings
+n_repeats: 6
+y_transformation: quantile_transform
+
+# Subsetting samples for training or association testing
+#sample_files:
+#  training: training_samples.pkl

--- a/pipelines/run_training.snakefile
+++ b/pipelines/run_training.snakefile
@@ -5,24 +5,18 @@ if not exists('./deeprvat_config.yaml'):
     if not config: #--configfile argument was not passed
         print("Generating deeprvat_config.yaml...")
         from deeprvat.deeprvat.config import create_main_config
-        create_main_config('deeprvat_input_config.yaml')
+        create_main_config('deeprvat_input_training_config.yaml')
         print("     Finished.")
 
 configfile: 'deeprvat_config.yaml'
 
 debug_flag = config.get('debug', False)
-phenotypes = config['phenotypes']
-phenotypes = list(phenotypes.keys()) if type(phenotypes) == dict else phenotypes
-training_phenotypes = config["training"].get("phenotypes", phenotypes)
+training_phenotypes = config["training"]["phenotypes"]
 training_phenotypes = list(training_phenotypes.keys()) if type(training_phenotypes) == dict else training_phenotypes
-
-n_burden_chunks = config.get('n_burden_chunks', 1) if not debug_flag else 2
-n_regression_chunks = config.get('n_regression_chunks', 40) if not debug_flag else 2
 n_trials = config['hyperparameter_optimization']['n_trials']
 n_bags = config['training']['n_bags'] if not debug_flag else 3
 n_repeats = config['n_repeats']
 debug = '--debug ' if debug_flag else ''
-do_scoretest = '--do-scoretest ' if config.get('do_scoretest', False) else ''
 tensor_compression_level = config['training'].get('tensor_compression_level', 1)
 model_path = Path("models")
 n_parallel_training_jobs = config["training"].get("n_parallel_jobs", 1)
@@ -53,8 +47,8 @@ rule all_training_dataset:
 rule all_config:
     input:
         seed_genes = expand('{phenotype}/deeprvat/seed_genes.parquet',
-                            phenotype=phenotypes),
+                            phenotype=training_phenotypes),
         data_config = expand('{phenotype}/deeprvat/config.yaml',
-                        phenotype=phenotypes),
+                        phenotype=training_phenotypes),
         baseline = expand('{phenotype}/deeprvat/baseline_results.parquet',
-                          phenotype=phenotypes),
+                          phenotype=training_phenotypes),


### PR DESCRIPTION
# What

Includes example config setup for running the training-only pipeline. This also updates the docs to reflect these updates as well as, adds additional PyTests to the GitHub actions for testing the `example/config` files.

# Testing
```
DEEPRVAT_REPO_PATH="[path_to_deeprvat]"
mkdir deeprvat_train
cd deeprvat_train
ln -s "$DEEPRVAT_REPO_PATH"/example/* .
ln -s config/deeprvat_input_training_config.yaml . #get the corresponding config.
snakemake -j 1 --snakefile "$DEEPRVAT_REPO_PATH"/pipelines/run_training.snakefile
```
