### PR TITLE
Add additional Github Action for checking pipeline output values

### DIFF
--- a/.github/workflows/pipeline-tests.yml
+++ b/.github/workflows/pipeline-tests.yml
@@ -46,9 +46,6 @@ jobs:
       run_training_results_check: true
 
   Reference-Output-Training:
-    # MOVE TO on pull_request.ready_for_review
-    #if: github.event.pull_request.opened == true
-    #if: GITHUB_REF == 'refs/pull/PULL_REQUEST_NUMBER/merge' #'refs/heads/master'
     uses: ./.github/workflows/run-pipeline.yml
     with:
       #branch: main

--- a/.github/workflows/pipeline-tests.yml
+++ b/.github/workflows/pipeline-tests.yml
@@ -25,7 +25,6 @@ jobs:
       environment_file: ./deeprvat_env_no_gpu.yml
       prerun_cmd: cp ./example/config/deeprvat_input_pretrained_models_config.yaml ./example/ && ln -s $GITHUB_WORKSPACE/pretrained_models ./example/
 
-
   # Training Pipeline
   Smoke-RunTraining:
     uses: ./.github/workflows/run-pipeline.yml
@@ -48,7 +47,7 @@ jobs:
   Reference-Output-Training:
     uses: ./.github/workflows/run-pipeline.yml
     with:
-      #branch: main
+      branch: main
       pipeline_file: ./pipelines/run_training.snakefile
       environment_file: ./deeprvat_env_no_gpu.yml
       prerun_cmd: cp ./tests/deeprvat/training_association_testing/deeprvat_config.yaml ./example/

--- a/.github/workflows/pipeline-tests.yml
+++ b/.github/workflows/pipeline-tests.yml
@@ -67,6 +67,16 @@ jobs:
       prerun_cmd: cp ./tests/deeprvat/pretrained/deeprvat_config.yaml ./example/
       dry_run: false
       upload_pretrained_outputs: true
+  
+  Reference-Output-Pretrained-Regenie:
+    uses: ./.github/workflows/run-pipeline.yml
+    with:
+      branch: main
+      pipeline_file: ./pipelines/association_testing_pretrained_regenie.snakefile
+      environment_file: ./deeprvat_env_no_gpu.yml
+      prerun_cmd: cp ./tests/deeprvat/regenie/pretrained/deeprvat_config.yaml ./example/
+      dry_run: false
+      upload_regenie_outputs: true
 
   # Association Testing Pretrained Pipeline
   Smoke-Association-Testing-Pretrained:
@@ -97,16 +107,16 @@ jobs:
       prerun_cmd: cp ./tests/deeprvat/regenie/pretrained/deeprvat_config.yaml ./example/
 
   Pipeline-Tests-Association-Testing-Pretrained-Regenie:
-    needs: [Smoke-Association-Testing-Pretrained-Regenie, Reference-Output-Pretrained]
+    needs: [Smoke-Association-Testing-Pretrained-Regenie, Reference-Output-Pretrained-Regenie]
     uses: ./.github/workflows/run-pipeline.yml
     with:
       pipeline_file: ./pipelines/association_testing_pretrained_regenie.snakefile
       environment_file: ./deeprvat_env_no_gpu.yml
       prerun_cmd: cp ./tests/deeprvat/regenie/pretrained/deeprvat_config.yaml ./example/
       dry_run: false
-      download_pretrained_outputs: true
-      run_burden_results_check: true
-      run_association_results_check: true
+      download_regenie_outputs: true
+      #run_burden_results_check: true
+      run_regenie_association_results_check: true
 
   # Association Testing Training
   Smoke-Association-Testing-Training:

--- a/.github/workflows/pipeline-tests.yml
+++ b/.github/workflows/pipeline-tests.yml
@@ -35,13 +35,41 @@ jobs:
       prerun_cmd: cp ./tests/deeprvat/training_association_testing/deeprvat_config.yaml ./example/
 
   Pipeline-Tests-RunTraining:
-    needs: Smoke-RunTraining
+    needs: [Smoke-RunTraining, Reference-Output-Training]
     uses: ./.github/workflows/run-pipeline.yml
     with:
       pipeline_file: ./pipelines/run_training.snakefile
       environment_file: ./deeprvat_env_no_gpu.yml
       prerun_cmd: cp ./tests/deeprvat/training_association_testing/deeprvat_config.yaml ./example/
       dry_run: false
+      download_training_outputs: true
+      run_training_results_check: true
+
+  Reference-Output-Training:
+    # MOVE TO on pull_request.ready_for_review
+    #if: github.event.pull_request.opened == true
+    #if: GITHUB_REF == 'refs/pull/PULL_REQUEST_NUMBER/merge' #'refs/heads/master'
+    uses: ./.github/workflows/run-pipeline.yml
+    with:
+      branch: main
+      pipeline_file: ./pipelines/run_training.snakefile
+      environment_file: ./deeprvat_env_no_gpu.yml
+      prerun_cmd: cp ./tests/deeprvat/training_association_testing/deeprvat_config.yaml ./example/
+      dry_run: false
+      upload_training_outputs: true
+
+  Reference-Output-Pretrained:
+    # MOVE TO on pull_request.ready_for_review
+    #if: github.event.pull_request.opened == true
+    #if: GITHUB_REF == 'refs/pull/PULL_REQUEST_NUMBER/merge' #'refs/heads/master'
+    uses: ./.github/workflows/run-pipeline.yml
+    with:
+      branch: main
+      pipeline_file: ./pipelines/association_testing_pretrained.snakefile
+      environment_file: ./deeprvat_env_no_gpu.yml
+      prerun_cmd: cp ./tests/deeprvat/pretrained/deeprvat_config.yaml ./example/
+      dry_run: false
+      upload_pretrained_outputs: true
 
   # Association Testing Pretrained Pipeline
   Smoke-Association-Testing-Pretrained:
@@ -52,13 +80,16 @@ jobs:
       prerun_cmd: cp ./tests/deeprvat/pretrained/deeprvat_config.yaml ./example/
 
   Pipeline-Tests-Training-Association-Testing:
-    needs: Smoke-Association-Testing-Pretrained
+    needs: [Smoke-Association-Testing-Pretrained, Reference-Output-Pretrained]
     uses: ./.github/workflows/run-pipeline.yml
     with:
       pipeline_file: ./pipelines/association_testing_pretrained.snakefile
       environment_file: ./deeprvat_env_no_gpu.yml
       prerun_cmd: cp ./tests/deeprvat/pretrained/deeprvat_config.yaml ./example/
       dry_run: false
+      download_pretrained_outputs: true
+      run_burden_results_check: true
+      run_association_results_check: true
 
   # Association Testing Pretrained Regenie
   Smoke-Association-Testing-Pretrained-Regenie:
@@ -69,13 +100,16 @@ jobs:
       prerun_cmd: cp ./tests/deeprvat/regenie/pretrained/deeprvat_config.yaml ./example/
 
   Pipeline-Tests-Association-Testing-Pretrained-Regenie:
-    needs: Smoke-Association-Testing-Pretrained-Regenie
+    needs: [Smoke-Association-Testing-Pretrained-Regenie, Reference-Output-Pretrained]
     uses: ./.github/workflows/run-pipeline.yml
     with:
       pipeline_file: ./pipelines/association_testing_pretrained_regenie.snakefile
       environment_file: ./deeprvat_env_no_gpu.yml
       prerun_cmd: cp ./tests/deeprvat/regenie/pretrained/deeprvat_config.yaml ./example/
       dry_run: false
+      download_outputs: true
+      run_burden_results_check: true
+      run_association_results_check: true
 
   # Association Testing Training
   Smoke-Association-Testing-Training:

--- a/.github/workflows/pipeline-tests.yml
+++ b/.github/workflows/pipeline-tests.yml
@@ -59,9 +59,6 @@ jobs:
       upload_training_outputs: true
 
   Reference-Output-Pretrained:
-    # MOVE TO on pull_request.ready_for_review
-    #if: github.event.pull_request.opened == true
-    #if: GITHUB_REF == 'refs/pull/PULL_REQUEST_NUMBER/merge' #'refs/heads/master'
     uses: ./.github/workflows/run-pipeline.yml
     with:
       branch: main

--- a/.github/workflows/pipeline-tests.yml
+++ b/.github/workflows/pipeline-tests.yml
@@ -51,7 +51,7 @@ jobs:
     #if: GITHUB_REF == 'refs/pull/PULL_REQUEST_NUMBER/merge' #'refs/heads/master'
     uses: ./.github/workflows/run-pipeline.yml
     with:
-      branch: main
+      #branch: main
       pipeline_file: ./pipelines/run_training.snakefile
       environment_file: ./deeprvat_env_no_gpu.yml
       prerun_cmd: cp ./tests/deeprvat/training_association_testing/deeprvat_config.yaml ./example/

--- a/.github/workflows/pipeline-tests.yml
+++ b/.github/workflows/pipeline-tests.yml
@@ -107,7 +107,7 @@ jobs:
       environment_file: ./deeprvat_env_no_gpu.yml
       prerun_cmd: cp ./tests/deeprvat/regenie/pretrained/deeprvat_config.yaml ./example/
       dry_run: false
-      download_outputs: true
+      download_pretrained_outputs: true
       run_burden_results_check: true
       run_association_results_check: true
 

--- a/.github/workflows/run-pipeline.yml
+++ b/.github/workflows/run-pipeline.yml
@@ -141,6 +141,8 @@ jobs:
             name: completed_pretrained_outputs
             path: |
               ./example/**/sample_ids.zarr/
+              ./example/**/y.zarr/
+              ./example/**/x.zarr/
               ./example/**/burdens.zarr/
               ./example/**/genes.npy
               ./example/**/all_results.parquet

--- a/.github/workflows/run-pipeline.yml
+++ b/.github/workflows/run-pipeline.yml
@@ -52,11 +52,19 @@ on:
         required: false
         default: false
         type: boolean
+      upload_regenie_outputs:
+        required: false
+        default: false
+        type: boolean
       download_training_outputs:
         required: false
         default: false
         type: boolean
       download_pretrained_outputs:
+        required: false
+        default: false
+        type: boolean
+      download_regenie_outputs:
         required: false
         default: false
         type: boolean
@@ -69,6 +77,10 @@ on:
         default: false
         type: boolean
       run_association_results_check:
+        required: false
+        default: false
+        type: boolean
+      run_regenie_association_results_check:
         required: false
         default: false
         type: boolean
@@ -148,6 +160,15 @@ jobs:
               ./example/**/all_results.parquet
             include-hidden-files: true #for .zarr needed
             retention-days: 1
+        - name: Upload Regenie Outputs
+          id: uploaded_regenie_outputs
+          if: inputs.upload_regenie_outputs
+          uses: actions/upload-artifact@v4
+          with:
+            name: completed_regenie_outputs
+            path: |
+              ./example/**/all_results.parquet
+            retention-days: 1
         - name: Download Previous Training Outputs
           id: downloaded_training_outputs
           if: inputs.download_training_outputs
@@ -162,6 +183,13 @@ jobs:
           with:
             name: completed_pretrained_outputs
             path: ./tests/completed_pretrained_outputs
+        - name: Download Previous Regenie Outputs
+          id: downloaded_regenie_outputs
+          if: inputs.download_regenie_outputs
+          uses: actions/download-artifact@v4
+          with:
+            name: completed_regenie_outputs
+            path: ./tests/completed_regenie_outputs
         # - name: Display structure of downloaded files
         #   if: inputs.download_outputs
         #   run: ls -R ./tests/completed_run_output
@@ -184,6 +212,13 @@ jobs:
           run: |
             python $GITHUB_WORKSPACE/tests/deeprvat/compare_reference.py compare-association \
             ./example/ ./tests/completed_pretrained_outputs/ \
+            "Cholesterol" "Platelet_count"
+          shell: micromamba-shell {0}
+        - name: Run REGENIE Association Results Check
+          if: inputs.run_regenie_association_results_check
+          run: |
+            python $GITHUB_WORKSPACE/tests/deeprvat/compare_reference.py compare-association \
+            ./example/ ./tests/completed_regenie_outputs/ \
             "Cholesterol" "Platelet_count"
           shell: micromamba-shell {0}
 

--- a/.github/workflows/run-pipeline.yml
+++ b/.github/workflows/run-pipeline.yml
@@ -6,6 +6,10 @@ on:
       environment_file:
         required: true
         type: string
+      branch:
+        required: false
+        default: ${{ github.ref_name }}
+        type: string
       prerun_cmd:
         required: false
         type: string
@@ -40,6 +44,34 @@ on:
       postrun_cmd:
         required: false
         type: string
+      upload_training_outputs:
+        required: false
+        default: false
+        type: boolean
+      upload_pretrained_outputs:
+        required: false
+        default: false
+        type: boolean
+      download_training_outputs:
+        required: false
+        default: false
+        type: boolean
+      download_pretrained_outputs:
+        required: false
+        default: false
+        type: boolean
+      run_training_results_check:
+        required: false
+        default: false
+        type: boolean
+      run_burden_results_check:
+        required: false
+        default: false
+        type: boolean
+      run_association_results_check:
+        required: false
+        default: false
+        type: boolean
 
 jobs:
   Run-Pipeline:
@@ -49,6 +81,8 @@ jobs:
       steps:
         - name: Check out repository code
           uses: actions/checkout@v4
+          with:
+            ref: ${{inputs.branch}}
         - uses: mamba-org/setup-micromamba@v1.8.1
           with:
             environment-file: ${{inputs.environment_file}}
@@ -85,3 +119,69 @@ jobs:
           if: inputs.postrun_cmd
           run: ${{inputs.postrun_cmd}}
           shell: micromamba-shell {0}
+        - name: Upload Training Outputs
+          id: uploaded_training_outputs
+          if: inputs.upload_training_outputs
+          uses: actions/upload-artifact@v4
+          with:
+            name: completed_training_outputs
+            path: |
+              ./example/**/seed_genes.parquet
+              ./example/**/covariates.zarr/
+              ./example/**/y.zarr/
+              ./example/**/input_tensor.zarr/
+              ./example/**/models/
+            include-hidden-files: true #for .zarr needed
+            retention-days: 1
+        - name: Upload Pretrained Outputs
+          id: uploaded_pretrained_outputs
+          if: inputs.upload_pretrained_outputs
+          uses: actions/upload-artifact@v4
+          with:
+            name: completed_pretrained_outputs
+            path: |
+              ./example/**/sample_ids.zarr/
+              ./example/**/burdens.zarr/
+              ./example/**/genes.npy
+              ./example/**/all_results.parquet
+            include-hidden-files: true #for .zarr needed
+            retention-days: 1
+        - name: Download Previous Training Outputs
+          id: downloaded_training_outputs
+          if: inputs.download_training_outputs
+          uses: actions/download-artifact@v4
+          with:
+            name: completed_training_outputs
+            path: ./tests/completed_training_outputs
+        - name: Download Previous Pretrained Outputs
+          id: downloaded_pretrained_outputs
+          if: inputs.download_pretrained_outputs
+          uses: actions/download-artifact@v4
+          with:
+            name: completed_pretrained_outputs
+            path: ./tests/completed_pretrained_outputs
+        # - name: Display structure of downloaded files
+        #   if: inputs.download_outputs
+        #   run: ls -R ./tests/completed_run_output
+        - name: Run Training Results Check
+          if: inputs.run_training_results_check
+          run: |
+            python $GITHUB_WORKSPACE/tests/deeprvat/compare_reference.py compare-training \
+            ./example/ ./tests/completed_training_outputs/ \
+            "Cholesterol" "Platelet_count"
+          shell: micromamba-shell {0}
+        - name: Run Burden Score Results Check
+          if: inputs.run_burden_results_check
+          run: |
+            python $GITHUB_WORKSPACE/tests/deeprvat/compare_reference.py compare-burdens \
+            ./example/ ./tests/completed_pretrained_outputs/ \
+            "Cholesterol" "Platelet_count"
+          shell: micromamba-shell {0}
+        - name: Run Association Results Check
+          if: inputs.run_association_results_check
+          run: |
+            python $GITHUB_WORKSPACE/tests/deeprvat/compare_reference.py compare-association \
+            ./example/ ./tests/completed_pretrained_outputs/ \
+            "Cholesterol" "Platelet_count"
+          shell: micromamba-shell {0}
+

--- a/deeprvat/deeprvat/train.py
+++ b/deeprvat/deeprvat/train.py
@@ -761,7 +761,6 @@ def run_bagging(
         torch.cuda.manual_seed(seed)
         torch.backends.cudnn.deterministic = True
         torch.backends.cudnn.benchmark = False
-        torch.mps.manual_seed(seed) # Only for Apple chips
 
     # if hyperparameter optimization is performed (train(); hpopt_file != None)
     if trial is not None:

--- a/deeprvat/deeprvat/train.py
+++ b/deeprvat/deeprvat/train.py
@@ -653,7 +653,7 @@ class MultiphenoBaggingData(pl.LightningDataModule):
         class_sizes = [idx.shape[0] for idx in class_indices]
         minority_class = 0 if class_sizes[0] < class_sizes[1] else 1
         minority_indices = class_indices[minority_class].detach().numpy()
-        rng = np.random.default_rng(seed=seed)
+        rng = np.random.default_rng(seed=self.seed)
         upsampled_indices = rng.choice(
             minority_indices,
             size=(self.upsampling_factor - 1) * class_sizes[minority_class],
@@ -754,8 +754,14 @@ def run_bagging(
 
     if deterministic:
         logger.info("Setting random seeds for reproducibility")
-        torch.manual_seed(42)
-        random.seed(42)
+        seed = 42
+        torch.manual_seed(seed)
+        random.seed(seed)
+        np.random.seed(seed)
+        torch.cuda.manual_seed(seed)
+        torch.backends.cudnn.deterministic = True
+        torch.backends.cudnn.benchmark = False
+        torch.mps.manual_seed(seed) # Only for Apple chips
 
     # if hyperparameter optimization is performed (train(); hpopt_file != None)
     if trial is not None:

--- a/tests/deeprvat/compare_reference.py
+++ b/tests/deeprvat/compare_reference.py
@@ -105,8 +105,6 @@ def compare_training(
         )
 
         if max_difference > tolerance:
-            #params_pairs = [(p1, p2) for p1, p2 in zip(model.parameters(), reference_model.parameters())]
-            #diff = [np.max(np.abs((np.array(model) - np.array(ref)))) for model,ref in params_pairs]
             diff = [(p2 - p1).abs().max().item() for p1, p2 in zip(model.parameters(), reference_model.parameters())]
             logger.info("Model and reference model parameter pair difference:\n %s", diff)
             raise RuntimeError(

--- a/tests/deeprvat/compare_reference.py
+++ b/tests/deeprvat/compare_reference.py
@@ -170,8 +170,8 @@ def compare_burdens(
                 all_close = np.array_equal(array, reference_array)
             else:
                 all_close = np.allclose(
-                    array.astype('float32'),
-                    reference_array.astype('float32'),
+                    array,
+                    reference_array,
                     equal_nan=True,
                     rtol=rtol_xy,
                     atol=atol_xy,

--- a/tests/deeprvat/compare_reference.py
+++ b/tests/deeprvat/compare_reference.py
@@ -107,7 +107,9 @@ def compare_training(
         if max_difference > tolerance:
             raise RuntimeError(
                 f"FAIL! Max difference between model and reference parameters (repeat {r}) "
-                f"differs by {max_difference} > {tolerance=}"
+                f"differs by {max_difference} > {tolerance=}\n"
+                f"REFERENCE Model Params: {reference_model.parameters()}\n\n"
+                f"Current Test Model Params; {model.parameters()}"
             )
         else:
             logger.info(
@@ -214,9 +216,11 @@ def compare_association(
         )
         string_cols = ["phenotype", "Method", "Discovery type"]
         for c in string_cols:
+            ref = reference_results[c].reset_index(drop=True)
+            test = results[c].reset_index(drop=True)
             assert (
-                (results[c].isna() & results[c].isna())
-                | (results[c] == reference_results[c])
+                (test.isna() & ref.isna())
+                | (test == ref)
             ).all()
 
         numerical_cols = ["gene", "beta", "pval", "-log10pval", "pval_corrected"]

--- a/tests/deeprvat/compare_reference.py
+++ b/tests/deeprvat/compare_reference.py
@@ -105,11 +105,16 @@ def compare_training(
         )
 
         if max_difference > tolerance:
-            diff = [(p2 - p1).abs().max().item() for p1, p2 in zip(model.parameters(), reference_model.parameters())]
-            logger.info("Model and reference model parameter pair difference:\n %s", diff)
+            diff = [
+                (p2 - p1).abs().max().item()
+                for p1, p2 in zip(model.parameters(), reference_model.parameters())
+            ]
+            logger.info(
+                "Model and reference model parameter pair difference:\n %s", diff
+            )
             raise RuntimeError(
                 f"FAIL! Max difference between model and reference parameters (repeat {r}) "
-                f"differs by {max_difference} > {tolerance=}\n"                
+                f"differs by {max_difference} > {tolerance=}\n"
             )
         else:
             logger.info(
@@ -218,10 +223,7 @@ def compare_association(
         for c in string_cols:
             ref = reference_results[c].reset_index(drop=True)
             test = results[c].reset_index(drop=True)
-            assert (
-                (test.isna() & ref.isna())
-                | (test == ref)
-            ).all()
+            assert ((test.isna() & ref.isna()) | (test == ref)).all()
 
         numerical_cols = ["gene", "beta", "pval", "-log10pval", "pval_corrected"]
         all_close = np.allclose(

--- a/tests/deeprvat/compare_reference.py
+++ b/tests/deeprvat/compare_reference.py
@@ -83,10 +83,10 @@ def compare_training(
     model_dir = results_dir / "models"
     model_reference_dir = reference_dir / "models"
 
-    with open(model_dir / "config.yaml") as f:
+    with open(model_dir / "model_config.yaml") as f:
         config = yaml.safe_load(f)
 
-    with open(model_reference_dir / "config.yaml") as f:
+    with open(model_reference_dir / "model_config.yaml") as f:
         reference_config = yaml.safe_load(f)
 
     for r in range(n_repeats):
@@ -157,8 +157,10 @@ def compare_burdens(
         if not all_close:
             raise RuntimeError(
                 f"FAIL! Max difference between results and reference results "
-                f"(array '{a}') larger than tolerance.\n"
-                f"{np.max(np.abs(reference_array - array))=}"
+                f"(array {a}) larger than tolerance.\n"
+                f"{reference_array}\n"
+                f"{array}"
+                #f"{np.max(np.abs(reference_array - array))=}"
             )
 
     for p in phenotype:
@@ -180,7 +182,7 @@ def compare_burdens(
             if not all_close:
                 raise RuntimeError(
                     f"FAIL! Max difference between results and reference results "
-                    f"(phenotype {p}, array '{a}') larger than tolerance"
+                    f"(phenotype {p}, array {a}) larger than tolerance"
                 )
 
         # else:

--- a/tests/deeprvat/compare_reference.py
+++ b/tests/deeprvat/compare_reference.py
@@ -105,8 +105,10 @@ def compare_training(
         )
 
         if max_difference > tolerance:
-            params_pairs = [(p1, p2) for p1, p2 in zip(model.parameters(), reference_model.parameters())]
-            logger.info("Model and reference model parameter pairs:\n %s", params_pairs)
+            #params_pairs = [(p1, p2) for p1, p2 in zip(model.parameters(), reference_model.parameters())]
+            #diff = [np.max(np.abs((np.array(model) - np.array(ref)))) for model,ref in params_pairs]
+            diff = [(p2 - p1).abs().max().item() for p1, p2 in zip(model.parameters(), reference_model.parameters())]
+            logger.info("Model and reference model parameter pair difference:\n %s", diff)
             raise RuntimeError(
                 f"FAIL! Max difference between model and reference parameters (repeat {r}) "
                 f"differs by {max_difference} > {tolerance=}\n"                

--- a/tests/deeprvat/compare_reference.py
+++ b/tests/deeprvat/compare_reference.py
@@ -105,11 +105,11 @@ def compare_training(
         )
 
         if max_difference > tolerance:
+            params_pairs = [(p1, p2) for p1, p2 in zip(model.parameters(), reference_model.parameters())]
+            logger.info("Model and reference model parameter pairs:\n %s", params_pairs)
             raise RuntimeError(
                 f"FAIL! Max difference between model and reference parameters (repeat {r}) "
-                f"differs by {max_difference} > {tolerance=}\n"
-                f"REFERENCE Model Params: {reference_model.parameters()}\n\n"
-                f"Current Test Model Params; {model.parameters()}"
+                f"differs by {max_difference} > {tolerance=}\n"                
             )
         else:
             logger.info(

--- a/tests/deeprvat/compare_reference.py
+++ b/tests/deeprvat/compare_reference.py
@@ -158,9 +158,7 @@ def compare_burdens(
             raise RuntimeError(
                 f"FAIL! Max difference between results and reference results "
                 f"(array {a}) larger than tolerance.\n"
-                f"{reference_array}\n"
-                f"{array}"
-                #f"{np.max(np.abs(reference_array - array))=}"
+                f"{np.max(np.abs(reference_array - array))=}"
             )
 
     for p in phenotype:
@@ -172,8 +170,8 @@ def compare_burdens(
                 all_close = np.array_equal(array, reference_array)
             else:
                 all_close = np.allclose(
-                    array,
-                    reference_array,
+                    array.astype('float32'),
+                    reference_array.astype('float32'),
                     equal_nan=True,
                     rtol=rtol_xy,
                     atol=atol_xy,

--- a/tests/deeprvat/training_association_testing/deeprvat_config.yaml
+++ b/tests/deeprvat/training_association_testing/deeprvat_config.yaml
@@ -133,6 +133,7 @@ baseline_results:
   - base: baseline_results
     type: missense/skat
 cv_exp: false
+deterministic: true
 do_scoretest: true
 evaluation:
   alpha: 0.05


### PR DESCRIPTION
# What

Adds additional GitHub actions for comparing pipeline output results in relation to the current working/PR branch to main branch. This verifies the results on the example data stay the same, within a specified tolerance, during code changes.

When the `deterministic` flag is set, a seed is set to address differences between runs. This is imperfect, hence the tolerance specification in [/tests/deeprvat/compare_reference.py](https://github.com/PMBio/deeprvat/blob/feature/chunked-writer-precomputed-burdens-testing-combo/tests/deeprvat/compare_reference.py)

# Testing
Running the various pipelines on two different testing branches, with the deterministic flag set in the config file, and comparing the outputs in the relevant GitHub action call that uses a test in compare_reference.py