### PR TITLE
Fix Allelic Imbalance Filtering Logic for bcftools v1.16+

### DIFF
--- a/pipelines/preprocessing/qc.snakefile
+++ b/pipelines/preprocessing/qc.snakefile
@@ -8,7 +8,7 @@ rule qc_allelic_imbalance:
     resources:
         mem_mb=lambda wildcards, attempt: 256 * attempt,
     shell:
-        f"""{load_bcftools} bcftools query --format '%CHROM\t%POS\t%REF\t%ALT\n' --exclude 'COUNT(GT="het")=0 || (GT="het" & ((TYPE="snp" & (FORMAT/AD[*:1] / FORMAT/AD[*:0]) > 0.15) | (TYPE="indel" & (FORMAT/AD[*:1] / FORMAT/AD[*:0]) > 0.20)))' {{input}} | gzip > {{output}}"""
+        f"""{load_bcftools} bcftools query --format '%CHROM\t%POS\t%REF\t%ALT\n' --exclude 'COUNT(GT="het")=0 || COUNT(GT="het" & ((TYPE="snp" & (FORMAT/AD[*:1] / FORMAT/AD[*:0]) > 0.15) | (TYPE="indel" & (FORMAT/AD[*:1] / FORMAT/AD[*:0]) > 0.20)))>0'  {{input}} | gzip > {{output}}"""
 
 
 rule qc_varmiss:


### PR DESCRIPTION
Fixing issue  #134 

# What

This update addresses an issue with the bcftools allelic imbalance filtering command introduced in versions later than v1.16. Specifically, we want to **exclude (write) variants only where all heterozygous calls have an allele balance (AB) < 0.15, but keep the variant if any heterozygous call has an AB > 0.15**.


The previous bcftools allelic imbalance filtering command 
```
bcftools query --format '%CHROM\t%POS\t%REF\t%ALT\n' --exclude 'COUNT(GT="het")=0 || 
(GT="het" & ((TYPE="snp" & (FORMAT/AD[*:1] / FORMAT/AD[*:0]) > 0.15) | (TYPE="indel" & (FORMAT/AD[*:1] / FORMAT/AD[*:0]) > 0.20)))' {{input}}
``` 
only had the intended behavior until bcftools v1.16. With newer versions, bcftools filtering logic seem sot have changed from an _any_  to _all_ evaluation. 
This results in all heterozygous variants being written to the variants to exclude file for versions > v1.16, even if a call meets the AB criterion. 

The fixed bcftools command (suggested by @rdey-inistro)
```
bcftools query --format '%CHROM\t%POS\t%REF\t%ALT\n' --exclude 'COUNT(GT="het")=0 || COUNT(GT="het" & ((TYPE="snp" & (FORMAT/AD[*:1] / FORMAT/AD[*:0]) > 0.15) | (TYPE="indel" & (FORMAT/AD[*:1] / FORMAT/AD[*:0]) > 0.20)))>0' {{input}} 
```
has the intended version for either bcftools version (<=v1.16  & >v1.16).

# Testing

The expected behavior of the new command was verified on the example vcf file using bcftools versions 1.12, 1.16, 1.18, 1.20.



