### PR TITLE
skip seak association testing if all burdens are constant

### DIFF
--- a/deeprvat/deeprvat/associate.py
+++ b/deeprvat/deeprvat/associate.py
@@ -1151,7 +1151,10 @@ def regress_on_gene_scoretest(
     if np.all(np.abs(burdens) < 1e-6):
         logger.warning(f"Burden for gene {gene} is 0 for all samples; skipping")
         return None
-
+        
+    if np.unique(burdens).shape[0] == 1:
+        logger.warning(f"Burdens for gene {gene} are all constant; skipping")
+        return None
     pv = model_score.pv_alt_model(burdens)
 
     logger.info(f"p-value: {pv}")

--- a/deeprvat/deeprvat/associate.py
+++ b/deeprvat/deeprvat/associate.py
@@ -1151,7 +1151,7 @@ def regress_on_gene_scoretest(
     if np.all(np.abs(burdens) < 1e-6):
         logger.warning(f"Burden for gene {gene} is 0 for all samples; skipping")
         return None
-        
+
     if np.unique(burdens).shape[0] == 1:
         logger.warning(f"Burdens for gene {gene} are all constant; skipping")
         return None


### PR DESCRIPTION
# What

This update skips association testing for constant burden vectors when using SEAK, as SEAK returns p-values of 0 for such cases. This can cause genes to be falsely considered significant. 

# Testing
Verified that association testing with all constant burdens now returns nan p-values. Verified that burden testing of non-constant burden behaves as before. 
