### PR TITLE
Enhancement/Remove Anaconda Defaults Channel

### DIFF
--- a/.github/workflows/pipeline-tests.yml
+++ b/.github/workflows/pipeline-tests.yml
@@ -34,7 +34,7 @@ jobs:
       prerun_cmd: cp ./tests/deeprvat/training_association_testing/deeprvat_config.yaml ./example/
 
   Pipeline-Tests-RunTraining:
-    needs: [Smoke-RunTraining, Reference-Output-Training]
+    needs: [Smoke-RunTraining] #, Reference-Output-Training]
     uses: ./.github/workflows/run-pipeline.yml
     with:
       pipeline_file: ./pipelines/run_training.snakefile
@@ -44,35 +44,35 @@ jobs:
       download_training_outputs: true
       run_training_results_check: true
 
-  Reference-Output-Training:
-    uses: ./.github/workflows/run-pipeline.yml
-    with:
-      branch: main
-      pipeline_file: ./pipelines/run_training.snakefile
-      environment_file: ./deeprvat_env_no_gpu.yml
-      prerun_cmd: cp ./tests/deeprvat/training_association_testing/deeprvat_config.yaml ./example/
-      dry_run: false
-      upload_training_outputs: true
+  # Reference-Output-Training:
+  #   uses: ./.github/workflows/run-pipeline.yml
+  #   with:
+  #     branch: main
+  #     pipeline_file: ./pipelines/run_training.snakefile
+  #     environment_file: ./deeprvat_env_no_gpu.yml
+  #     prerun_cmd: cp ./tests/deeprvat/training_association_testing/deeprvat_config.yaml ./example/
+  #     dry_run: false
+  #     upload_training_outputs: true
 
-  Reference-Output-Pretrained:
-    uses: ./.github/workflows/run-pipeline.yml
-    with:
-      branch: main
-      pipeline_file: ./pipelines/association_testing_pretrained.snakefile
-      environment_file: ./deeprvat_env_no_gpu.yml
-      prerun_cmd: cp ./tests/deeprvat/pretrained/deeprvat_config.yaml ./example/
-      dry_run: false
-      upload_pretrained_outputs: true
+  # Reference-Output-Pretrained:
+  #   uses: ./.github/workflows/run-pipeline.yml
+  #   with:
+  #     branch: main
+  #     pipeline_file: ./pipelines/association_testing_pretrained.snakefile
+  #     environment_file: ./deeprvat_env_no_gpu.yml
+  #     prerun_cmd: cp ./tests/deeprvat/pretrained/deeprvat_config.yaml ./example/
+  #     dry_run: false
+  #     upload_pretrained_outputs: true
   
-  Reference-Output-Pretrained-Regenie:
-    uses: ./.github/workflows/run-pipeline.yml
-    with:
-      branch: main
-      pipeline_file: ./pipelines/association_testing_pretrained_regenie.snakefile
-      environment_file: ./deeprvat_env_no_gpu.yml
-      prerun_cmd: cp ./tests/deeprvat/regenie/pretrained/deeprvat_config.yaml ./example/
-      dry_run: false
-      upload_regenie_outputs: true
+  # Reference-Output-Pretrained-Regenie:
+  #   uses: ./.github/workflows/run-pipeline.yml
+  #   with:
+  #     branch: main
+  #     pipeline_file: ./pipelines/association_testing_pretrained_regenie.snakefile
+  #     environment_file: ./deeprvat_env_no_gpu.yml
+  #     prerun_cmd: cp ./tests/deeprvat/regenie/pretrained/deeprvat_config.yaml ./example/
+  #     dry_run: false
+  #     upload_regenie_outputs: true
 
   # Association Testing Pretrained Pipeline
   Smoke-Association-Testing-Pretrained:
@@ -83,7 +83,7 @@ jobs:
       prerun_cmd: cp ./tests/deeprvat/pretrained/deeprvat_config.yaml ./example/
 
   Pipeline-Tests-Training-Association-Testing:
-    needs: [Smoke-Association-Testing-Pretrained, Reference-Output-Pretrained]
+    needs: [Smoke-Association-Testing-Pretrained] #, Reference-Output-Pretrained]
     uses: ./.github/workflows/run-pipeline.yml
     with:
       pipeline_file: ./pipelines/association_testing_pretrained.snakefile
@@ -103,7 +103,7 @@ jobs:
       prerun_cmd: cp ./tests/deeprvat/regenie/pretrained/deeprvat_config.yaml ./example/
 
   Pipeline-Tests-Association-Testing-Pretrained-Regenie:
-    needs: [Smoke-Association-Testing-Pretrained-Regenie, Reference-Output-Pretrained-Regenie]
+    needs: [Smoke-Association-Testing-Pretrained-Regenie] #, Reference-Output-Pretrained-Regenie]
     uses: ./.github/workflows/run-pipeline.yml
     with:
       pipeline_file: ./pipelines/association_testing_pretrained_regenie.snakefile

--- a/.github/workflows/pipeline-tests.yml
+++ b/.github/workflows/pipeline-tests.yml
@@ -34,45 +34,45 @@ jobs:
       prerun_cmd: cp ./tests/deeprvat/training_association_testing/deeprvat_config.yaml ./example/
 
   Pipeline-Tests-RunTraining:
-    needs: [Smoke-RunTraining] #, Reference-Output-Training]
+    needs: [Smoke-RunTraining, Reference-Output-Training]
     uses: ./.github/workflows/run-pipeline.yml
     with:
       pipeline_file: ./pipelines/run_training.snakefile
       environment_file: ./deeprvat_env_no_gpu.yml
       prerun_cmd: cp ./tests/deeprvat/training_association_testing/deeprvat_config.yaml ./example/
       dry_run: false
-      #download_training_outputs: true
-      #run_training_results_check: true
+      download_training_outputs: true
+      run_training_results_check: true
 
-  # Reference-Output-Training:
-  #   uses: ./.github/workflows/run-pipeline.yml
-  #   with:
-  #     branch: main
-  #     pipeline_file: ./pipelines/run_training.snakefile
-  #     environment_file: ./deeprvat_env_no_gpu.yml
-  #     prerun_cmd: cp ./tests/deeprvat/training_association_testing/deeprvat_config.yaml ./example/
-  #     dry_run: false
-  #     upload_training_outputs: true
+  Reference-Output-Training:
+    uses: ./.github/workflows/run-pipeline.yml
+    with:
+      branch: main
+      pipeline_file: ./pipelines/run_training.snakefile
+      environment_file: ./deeprvat_env_no_gpu.yml
+      prerun_cmd: cp ./tests/deeprvat/training_association_testing/deeprvat_config.yaml ./example/
+      dry_run: false
+      upload_training_outputs: true
 
-  # Reference-Output-Pretrained:
-  #   uses: ./.github/workflows/run-pipeline.yml
-  #   with:
-  #     branch: main
-  #     pipeline_file: ./pipelines/association_testing_pretrained.snakefile
-  #     environment_file: ./deeprvat_env_no_gpu.yml
-  #     prerun_cmd: cp ./tests/deeprvat/pretrained/deeprvat_config.yaml ./example/
-  #     dry_run: false
-  #     upload_pretrained_outputs: true
+  Reference-Output-Pretrained:
+    uses: ./.github/workflows/run-pipeline.yml
+    with:
+      branch: main
+      pipeline_file: ./pipelines/association_testing_pretrained.snakefile
+      environment_file: ./deeprvat_env_no_gpu.yml
+      prerun_cmd: cp ./tests/deeprvat/pretrained/deeprvat_config.yaml ./example/
+      dry_run: false
+      upload_pretrained_outputs: true
   
-  # Reference-Output-Pretrained-Regenie:
-  #   uses: ./.github/workflows/run-pipeline.yml
-  #   with:
-  #     branch: main
-  #     pipeline_file: ./pipelines/association_testing_pretrained_regenie.snakefile
-  #     environment_file: ./deeprvat_env_no_gpu.yml
-  #     prerun_cmd: cp ./tests/deeprvat/regenie/pretrained/deeprvat_config.yaml ./example/
-  #     dry_run: false
-  #     upload_regenie_outputs: true
+  Reference-Output-Pretrained-Regenie:
+    uses: ./.github/workflows/run-pipeline.yml
+    with:
+      branch: main
+      pipeline_file: ./pipelines/association_testing_pretrained_regenie.snakefile
+      environment_file: ./deeprvat_env_no_gpu.yml
+      prerun_cmd: cp ./tests/deeprvat/regenie/pretrained/deeprvat_config.yaml ./example/
+      dry_run: false
+      upload_regenie_outputs: true
 
   # Association Testing Pretrained Pipeline
   Smoke-Association-Testing-Pretrained:
@@ -83,16 +83,16 @@ jobs:
       prerun_cmd: cp ./tests/deeprvat/pretrained/deeprvat_config.yaml ./example/
 
   Pipeline-Tests-Training-Association-Testing:
-    needs: [Smoke-Association-Testing-Pretrained] #, Reference-Output-Pretrained]
+    needs: [Smoke-Association-Testing-Pretrained, Reference-Output-Pretrained]
     uses: ./.github/workflows/run-pipeline.yml
     with:
       pipeline_file: ./pipelines/association_testing_pretrained.snakefile
       environment_file: ./deeprvat_env_no_gpu.yml
       prerun_cmd: cp ./tests/deeprvat/pretrained/deeprvat_config.yaml ./example/
       dry_run: false
-      #download_pretrained_outputs: true
-      #run_burden_results_check: true
-      #run_association_results_check: true
+      download_pretrained_outputs: true
+      run_burden_results_check: true
+      run_association_results_check: true
 
   # Association Testing Pretrained Regenie
   Smoke-Association-Testing-Pretrained-Regenie:
@@ -103,15 +103,15 @@ jobs:
       prerun_cmd: cp ./tests/deeprvat/regenie/pretrained/deeprvat_config.yaml ./example/
 
   Pipeline-Tests-Association-Testing-Pretrained-Regenie:
-    needs: [Smoke-Association-Testing-Pretrained-Regenie] #, Reference-Output-Pretrained-Regenie]
+    needs: [Smoke-Association-Testing-Pretrained-Regenie, Reference-Output-Pretrained-Regenie]
     uses: ./.github/workflows/run-pipeline.yml
     with:
       pipeline_file: ./pipelines/association_testing_pretrained_regenie.snakefile
       environment_file: ./deeprvat_env_no_gpu.yml
       prerun_cmd: cp ./tests/deeprvat/regenie/pretrained/deeprvat_config.yaml ./example/
       dry_run: false
-      #download_regenie_outputs: true
-      #run_regenie_association_results_check: true
+      download_regenie_outputs: true
+      run_regenie_association_results_check: true
 
   # Association Testing Training
   Smoke-Association-Testing-Training:

--- a/.github/workflows/pipeline-tests.yml
+++ b/.github/workflows/pipeline-tests.yml
@@ -41,8 +41,8 @@ jobs:
       environment_file: ./deeprvat_env_no_gpu.yml
       prerun_cmd: cp ./tests/deeprvat/training_association_testing/deeprvat_config.yaml ./example/
       dry_run: false
-      download_training_outputs: true
-      run_training_results_check: true
+      #download_training_outputs: true
+      #run_training_results_check: true
 
   # Reference-Output-Training:
   #   uses: ./.github/workflows/run-pipeline.yml
@@ -90,9 +90,9 @@ jobs:
       environment_file: ./deeprvat_env_no_gpu.yml
       prerun_cmd: cp ./tests/deeprvat/pretrained/deeprvat_config.yaml ./example/
       dry_run: false
-      download_pretrained_outputs: true
-      run_burden_results_check: true
-      run_association_results_check: true
+      #download_pretrained_outputs: true
+      #run_burden_results_check: true
+      #run_association_results_check: true
 
   # Association Testing Pretrained Regenie
   Smoke-Association-Testing-Pretrained-Regenie:
@@ -110,9 +110,8 @@ jobs:
       environment_file: ./deeprvat_env_no_gpu.yml
       prerun_cmd: cp ./tests/deeprvat/regenie/pretrained/deeprvat_config.yaml ./example/
       dry_run: false
-      download_regenie_outputs: true
-      #run_burden_results_check: true
-      run_regenie_association_results_check: true
+      #download_regenie_outputs: true
+      #run_regenie_association_results_check: true
 
   # Association Testing Training
   Smoke-Association-Testing-Training:

--- a/deeprvat_annotations.yml
+++ b/deeprvat_annotations.yml
@@ -1,7 +1,6 @@
 name: deeprvat_annotations
 channels:
   - conda-forge
-  - defaults
   - bioconda
 dependencies:
   - python=3.9.16

--- a/deeprvat_env.yaml
+++ b/deeprvat_env.yaml
@@ -4,7 +4,6 @@ channels:
   - nvidia
   - conda-forge
   - bioconda
-  - defaults
 dependencies:
   - click=8.1
   - cudatoolkit=11.8

--- a/deeprvat_env_no_gpu.yml
+++ b/deeprvat_env_no_gpu.yml
@@ -3,6 +3,7 @@ channels:
   - pytorch
   - conda-forge
   - bioconda
+  - default
 dependencies:
   - click=8.1
   - dask=2023.5

--- a/deeprvat_env_no_gpu.yml
+++ b/deeprvat_env_no_gpu.yml
@@ -3,7 +3,6 @@ channels:
   - pytorch
   - conda-forge
   - bioconda
-  - defaults
 dependencies:
   - click=8.1
   - dask=2023.5

--- a/deeprvat_env_no_gpu.yml
+++ b/deeprvat_env_no_gpu.yml
@@ -3,13 +3,12 @@ channels:
   - pytorch
   - conda-forge
   - bioconda
-  - default
 dependencies:
   - click=8.1
   - dask=2023.5
   - fastparquet=0.5
   - h5py=3.1
-  - mkl!=2024.1.0
+  - mkl==2022.1.0
   - numcodecs=0.11
   - numpy=1.21
   - optuna=2.10


### PR DESCRIPTION
# What
Removes the anaconda defaults channel from the environment yaml files. 
Also, pins mkl package version in yaml files, due to bug in newer versions causing the below error when `import torch` is used : 
`virt_env/lib/python3.8/site-packages/torch/lib/libtorch_cpu.so: undefined symbol: iJIT_NotifyEvent`

# Testing
Running Github Actions, tests already built into repository.
