### PR TITLE
Remove BgenWriter metadata field.

### DIFF
--- a/deeprvat/deeprvat/associate.py
+++ b/deeprvat/deeprvat/associate.py
@@ -447,7 +447,6 @@ def make_regenie_input_(
             bgen,
             n_samples,
             samples=list(sample_ids.astype(str)),
-            metadata="Pseudovariants containing DeepRVAT gene impairment scores. One pseudovariant per gene.",
         ) as f:
             for i in trange(n_genes):
                 varid = f"pseudovariant_gene_{ensgids[i]}"


### PR DESCRIPTION
# What
Removes the metadata description field from the BgenWriter, due to a bug in the BgenWriter/BgenReader code that causes bugs in the probabilities/dosages calculations from the resulting .bgen file.

# Testing
Tested by creating example datasets and using BgenWriter and BgenReader to create and view the resulting incorrect/errored .bgen, respectively. 

Note: In future version releases of the bgen repository, this function may again be working correctly and the metadata field could be added back in. 
Current problematic bgen version : 1.7.2